### PR TITLE
Multi-job metric collection improvements

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -95,7 +95,6 @@ func setupCreateJob(jobConfig config.Job) Executor {
 // RunCreateJob executes a creation job
 func (ex *Executor) RunCreateJob() {
 	log.Infof("Triggering job: %s", ex.Config.Name)
-	ex.Start = time.Now().UTC()
 	nsLabels := map[string]string{
 		"kube-burner-job":  ex.Config.Name,
 		"kube-burner-uuid": ex.uuid,

--- a/pkg/burner/delete.go
+++ b/pkg/burner/delete.go
@@ -92,7 +92,12 @@ func (ex *Executor) RunDeleteJob() {
 				if err != nil {
 					log.Errorf("Error found removing %s %s: %s", item.GetKind(), item.GetName(), err)
 				} else {
-					log.Infof("Removing %s %s", item.GetKind(), item.GetName())
+					ns := item.GetNamespace()
+					if ns != "" {
+						log.Infof("Removing %s %s from namespace %s", item.GetKind(), item.GetName(), ns)
+					} else {
+						log.Infof("Removing %s %s", item.GetKind(), item.GetName())
+					}
 				}
 			}(item)
 		}

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -65,7 +65,7 @@ func NewExecutorList(uuid string) []Executor {
 	var executorList []Executor
 	RestConfig, err = config.GetRestConfig(0, 0)
 	if err != nil {
-		log.Fatalf("Error creating restConfig for kube-burner: %s", err)
+		log.Fatalf("Error creating restConfig: %s", err)
 	}
 	ClientSet = kubernetes.NewForConfigOrDie(RestConfig)
 	for _, job := range config.ConfigSpec.Jobs {

--- a/pkg/burner/metadata.go
+++ b/pkg/burner/metadata.go
@@ -30,17 +30,19 @@ type metadata struct {
 	JobConfig   config.Job `json:"jobConfig"`
 }
 
+const jobSummary = "jobSummary"
+
 // IndexMetadataInfo Generates and indexes a document with metadata information of the passed job
-func IndexMetadataInfo(indexer *indexers.Indexer, uuid string, elapsedTime float64, jobConfig config.Job) {
+func IndexMetadataInfo(indexer *indexers.Indexer, uuid string, elapsedTime float64, jobConfig config.Job, timestamp time.Time) {
 	metadataInfo := []interface{}{
 		metadata{
 			UUID:        uuid,
 			ElapsedTime: elapsedTime,
 			JobConfig:   jobConfig,
-			MetricName:  "jobSummary",
-			Timestamp:   time.Now(),
+			MetricName:  jobSummary,
+			Timestamp:   timestamp,
 		},
 	}
-	log.Info("Indexing metadata information")
+	log.Info("Indexing metadata information for job: %s", jobConfig.Name)
 	(*indexer).Index(config.ConfigSpec.GlobalConfig.IndexerConfig.DefaultIndex, metadataInfo)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -129,10 +129,10 @@ func GetRestConfig(QPS, burst int) (*rest.Config, error) {
 		kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	}
 	if kubeconfig != "" {
-		log.Infof("Using kubeconfig: %s", kubeconfig)
+		log.Debugf("Using kubeconfig: %s", kubeconfig)
 		restConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 	} else {
-		log.Info("Using in-cluster configuration")
+		log.Debugf("Using in-cluster configuration")
 		restConfig, err = rest.InClusterConfig()
 	}
 	if err != nil {

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -92,7 +92,7 @@ func (p *podLatency) createPod(obj interface{}) {
 				Name:       pod.Name,
 				MetricName: podLatencyMeasurement,
 				UUID:       factory.uuid,
-				JobName:    config.ConfigSpec.Jobs[0].Name,
+				JobName:    factory.config.Name,
 			}
 		}
 	}
@@ -248,8 +248,8 @@ func calcQuantiles() {
 		podQ := podLatencyQuantiles{
 			QuantileName: quantileName,
 			UUID:         factory.uuid,
-			Timestamp:    time.Now(),
-			JobName:      config.ConfigSpec.Jobs[0].Name,
+			Timestamp:    time.Now().UTC(),
+			JobName:      factory.config.Name,
 			MetricName:   podLatencyQuantilesMeasurement,
 		}
 		sort.Ints(v)

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -269,10 +269,7 @@ func (p *Prometheus) parseMatrix(metricName, query string, jobList []burner.Exec
 	}
 	for _, v := range data {
 		for _, val := range v.Values {
-			jobName, err := getJobName(val.Timestamp.Time(), jobList)
-			if err != nil {
-				log.Warnf("Couldn't determine job from timestmap: %s", val.Timestamp.Time())
-			}
+			jobName := getJobName(val.Timestamp.Time(), jobList)
 			m := metric{
 				Labels:     make(map[string]string),
 				UUID:       p.uuid,
@@ -298,13 +295,13 @@ func (p *Prometheus) parseMatrix(metricName, query string, jobList []burner.Exec
 	return nil
 }
 
-func getJobName(timestamp time.Time, jobList []burner.Executor) (string, error) {
+func getJobName(timestamp time.Time, jobList []burner.Executor) string {
 	for _, j := range jobList {
 		if timestamp.Before(j.End) {
-			return j.Config.Name, nil
+			return j.Config.Name
 		}
 	}
-	return "kube-burner-indexing", nil
+	return "kube-burner-indexing"
 }
 
 // Query prometheues query wrapper


### PR DESCRIPTION
benchmarks all metrics were tagged with the name of the first job.
With this change metrics are now tagged to the right job depending on their timestamp.

In addition, when triggering now kube-burner index, kube-burner metrics ara tagged with the jobName "kube-burner-indexing".
Some log messages have been improved as well.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>