### PR TITLE
Fix semaphore error when accesing to labels map and improve namespace creation error handling

### DIFF
--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -16,6 +16,7 @@ package burner
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cloud-bulldozer/kube-burner/log"
@@ -27,7 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func createNamespace(clientset *kubernetes.Clientset, namespaceName string, nsLabels map[string]string) {
+func createNamespace(clientset *kubernetes.Clientset, namespaceName string, nsLabels map[string]string) error {
 	ns := v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: namespaceName, Labels: nsLabels},
 	}
@@ -39,8 +40,9 @@ func createNamespace(clientset *kubernetes.Clientset, namespaceName string, nsLa
 	if errors.IsAlreadyExists(err) {
 		log.Warnf("Namespace %s already exists", ns.Name)
 	} else if err != nil {
-		log.Errorf("Unexpected error creating namespace: %s", err)
+		return fmt.Errorf("Unexpected error creating namespace: %s", err)
 	}
+	return nil
 }
 
 // CleanupNamespaces deletes namespaces with the given selector


### PR DESCRIPTION
Executing kubelet-density with a wrong cofiguration file leads into semaphore acquire issues
```
ERRO[2021-01-22 17:35:27] Pod/kubelet-density-25 in namespace kubelet-density already exists                           
ERRO[2021-01-22 17:35:27] Pod/kubelet-density-25 in namespace kubelet-density already exists                                                                                                                                                  
ERRO[2021-01-22 17:35:27] Pod/kubelet-density-25 in namespace kubelet-density already exists                           
ERRO[2021-01-22 17:35:27] Pod/kubelet-density-25 in namespace kubelet-density already exists                                                                                                                                                  
ERRO[2021-01-22 17:35:27] Pod/kubelet-density-25 in namespace kubelet-density already exists                           
ERRO[2021-01-22 17:35:28] Pod/kubelet-density-25 in namespace kubelet-density already exists                                                                                                                                                  
ERRO[2021-01-22 17:35:28] Pod/kubelet-density-25 in namespace kubelet-density already exists                                                                                                                                                  
ERRO[2021-01-22 17:35:28] Pod/kubelet-density-25 in namespace kubelet-density already exists                                                                                                                                                  
ERRO[2021-01-22 17:35:28] Pod/kubelet-density-25 in namespace kubelet-density already exists                           
ERRO[2021-01-22 17:35:28] Pod/kubelet-density-25 in namespace kubelet-density already exists                                                                                                                                                  
ERRO[2021-01-22 17:35:28] Pod/kubelet-density-25 in namespace kubelet-density already exists                           
ERRO[2021-01-22 17:35:28] Pod/kubelet-density-25 in namespace kubelet-density already exists                                                                                                                                                  
fatal error: concurrent map writes                                                                                     
                                                                                                                                                                                                                                              
goroutine 12689 [running]:                                                                                             
runtime.throw(0x1a1653b, 0x15)                                                                                                                                                                                                                
        /usr/lib/golang/src/runtime/panic.go:1116 +0x72 fp=0xc00d7a1d50 sp=0xc00d7a1d20 pc=0x435cb2                                                                                                                                           
runtime.mapassign_faststr(0x18241e0, 0xc002fc8690, 0xc0014826ac, 0x4, 0xc00313d920)                                                                                                                                                           
        /usr/lib/golang/src/runtime/map_faststr.go:211 +0x3f1 fp=0xc00d7a1db8 sp=0xc00d7a1d50 pc=0x414331              
github.com/cloud-bulldozer/kube-burner/pkg/burner.(*Executor).replicaHandler.func1(0xc000122694, 0xc0001e0200, 0xc0013f7870, 0xc002fc86c0, 0x0, 0x0, 0xc00045e5f8, 0x2, 0xc00045e80c, 0x4, ...)                                               
        /home/rsevilla/labs/kube-burner/pkg/burner/create.go:189 +0x365 fp=0xc00d7a1f28 sp=0xc00d7a1db8 pc=0x165aaa5   
runtime.goexit()                                                                                                                                                                                                                              
        /usr/lib/golang/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc00d7a1f30 sp=0xc00d7a1f28 pc=0x46a521                  
created by github.com/cloud-bulldozer/kube-burner/pkg/burner.(*Executor).replicaHandler                                                                                                                                                       
        /home/rsevilla/labs/kube-burner/pkg/burner/create.go:172 +0x5b8                                                
                                                                                                                                                                                                                                              
goroutine 1 [semacquire]:                                                                                              
sync.runtime_Semacquire(0xc000122694)                                                                                                                                                                                                         
        /usr/lib/golang/src/runtime/sema.go:56 +0x45                                                                   
sync.(*WaitGroup).Wait(0xc000122694)                                              
```

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>