### PR TITLE
Use go-template to render configuration file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,15 @@
 
-All the magic `kube-burner` does is described in the configuration file. As previoysly mentioned the location of this configuration file is provided by the flag `-c`. This file is written in YAML format and has several sections.
+All the magic `kube-burner` does is described in the configuration file. As previously mentioned the location of this configuration file is provided by the flag `-c`. This file is written in YAML format and consists of several sections.
+It's possible to use `go-template` syntax within this configuration file, also it's important to note that every environment variable is passed to this template, so we can reference them using the syntax `{{ .MY_ENV_VAR}}`. For example, we could define the indexerConfig section of our configuration file like:
+
+```yaml
+  enabled: true
+  type: elastic
+  esServers: [{{ .ES_SERVER }}]
+  defaultIndex: elasticsearch-index
+```
+
+This feature can be very useful at the time of defining secrets such as the user and password of our indexer, or a token to use in pprof collection.
 
 # Global 
 
@@ -12,7 +22,7 @@ In this section is described global job configuration, it holds the following pa
 | metricsDirectory | Directory where collected metrics will be dumped into. It will be created if it doesn't exist previously | String         | ./metrics      | ./collected-metrics | 
 | measurements     | List of measurements. Detailed in the [measurements section]                                             | List           | -              | []          |
 | indexerConfig    | Holds the indexer configuration. Detailed in the [indexers section]                                      | Object         | -              | -           |
-| requestTimeout    | Client-go request timeout                                                                               | Duration       | 5s             | 15s         |
+| requestTimeout   | Client-go request timeout                                                                                | Duration       | 5s             | 15s         |
 
 # Jobs
 

--- a/pkg/indexers/elastic.go
+++ b/pkg/indexers/elastic.go
@@ -41,7 +41,8 @@ func init() {
 	indexerMap[elastic] = &Elastic{}
 }
 
-func (esIndexer *Elastic) new(esConfig config.IndexerConfig) {
+func (esIndexer *Elastic) new() {
+	esConfig := config.ConfigSpec.GlobalConfig.IndexerConfig
 	cfg := elasticsearch.Config{
 		Addresses: esConfig.ESServers,
 		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: esConfig.InsecureSkipVerify}},

--- a/pkg/indexers/factory.go
+++ b/pkg/indexers/factory.go
@@ -22,7 +22,7 @@ import (
 // Indexer indexer interface
 type Indexer interface {
 	Index(string, []interface{})
-	new(config.IndexerConfig)
+	new()
 }
 
 var indexerMap = make(map[string]Indexer)
@@ -34,7 +34,7 @@ func NewIndexer() *Indexer {
 	cfg := config.ConfigSpec.GlobalConfig.IndexerConfig
 	if indexer, exists = indexerMap[cfg.Type]; exists {
 		log.Infof("📁 Creating indexer: %s", cfg.Type)
-		indexer.new(cfg)
+		indexer.new()
 	} else {
 		log.Fatalf("Indexer not found: %s", cfg.Type)
 	}

--- a/pkg/util/url_reader.go
+++ b/pkg/util/url_reader.go
@@ -31,14 +31,13 @@ func ReadConfig(configFile string) (io.Reader, error) {
 	// If the template file does not exist we try to read it from an URL
 	if os.IsNotExist(err) {
 		log.Warnf("Configuration file %s not found, trying to read from URL", configFile)
-		f, err = readURL(configFile)
+		f, err = readURL(configFile, f)
 	}
 	return f, err
 }
 
 // readURL reads an URL and returns a reader
-func readURL(stringURL string) (io.Reader, error) {
-	var body io.Reader
+func readURL(stringURL string, body io.Reader) (io.Reader, error) {
 	u, err := url.Parse(stringURL)
 	if err != nil {
 		return body, err

--- a/test/base.sh
+++ b/test/base.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export QPS=5
+export BURST=10
 export TERM=screen-256color
 
 bold=$(tput bold)

--- a/test/kube-burner.yml
+++ b/test/kube-burner.yml
@@ -14,8 +14,8 @@ jobs:
   - name: namespaced
     jobType: create
     jobIterations: 5
-    qps: 5
-    burst: 15
+    qps: {{ .QPS }}
+    burst: {{ .BURST }}
     namespacedIterations: true
     cleanup: true
     namespace: namespaced


### PR DESCRIPTION
# Description
Use go-template to render configuration file. This allow kube-burner to reference environment variables in the configuration.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>


