### PR TITLE
Take advantage of the custom template functions in the main config rendering

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,8 +18,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    environment:
-      name: kube-burner
     strategy:
       matrix:
         golang-version: [1.14, 1.15]
@@ -79,8 +77,6 @@ jobs:
 
   lint:
     name: Run golangci-lint
-    environment:
-      name: kube-burner
     runs-on: ubuntu-latest
     steps:
 
@@ -105,8 +101,6 @@ jobs:
 
   build-container:
     name: Build container image
-    environment:
-      name: kube-burner
     runs-on: ubuntu-latest
     steps:
 

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -194,7 +194,7 @@ func (ex *Executor) replicaHandler(objectIndex int, obj object, ns string, itera
 			ex.limiter.Wait(context.TODO())
 			newObject := &unstructured.Unstructured{}
 			templateData[replica] = r
-			renderedObj, err := renderTemplate(obj.objectSpec, templateData, missingKeyError)
+			renderedObj, err := util.RenderTemplate(obj.objectSpec, templateData, util.MissingKeyError)
 			if err != nil {
 				log.Fatalf("Template error in %s: %s", obj.objectTemplate, err)
 			}

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -1,0 +1,70 @@
+// Copyright 2021 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"text/template"
+	"time"
+)
+
+type templateOption string
+
+const (
+	MissingKeyError templateOption = "missingkey=error"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+//RenderTemplate renders a go-template and adds several custom functions
+func RenderTemplate(original []byte, inputData interface{}, options templateOption) ([]byte, error) {
+	var rendered bytes.Buffer
+	funcMap := template.FuncMap{
+		"add": func(a int, b int) int {
+			return a + b
+		},
+		"multiply": func(a int, b int) int {
+			return a * b
+		},
+		"rand": func(length int) string {
+			var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+			b := make([]rune, length)
+			for i := range b {
+				b[i] = letterRunes[rand.Intn(len(letterRunes))]
+			}
+			return string(b)
+		},
+		"sequence": func(start int, end int) []int {
+			var sequence = []int{}
+			for i := start; i <= end; i++ {
+				sequence = append(sequence, i)
+			}
+			return sequence
+		},
+	}
+	t, err := template.New("").Option(string(options)).Funcs(funcMap).Parse(string(original))
+	if err != nil {
+		return nil, fmt.Errorf("Parsing error: %s", err)
+	}
+	err = t.Execute(&rendered, inputData)
+	if err != nil {
+		return nil, fmt.Errorf("Rendering error: %s", err)
+	}
+	return rendered.Bytes(), nil
+}


### PR DESCRIPTION
### Description
Move the template rendering code to the util package to be reused in the main config rendering.


Signed-off-by: Raul Sevilla <rsevilla@redhat.com>


