### PR TITLE
Add retry logic to namespace creation

### DIFF
--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -16,7 +16,6 @@ package burner
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/cloud-bulldozer/kube-burner/log"
@@ -32,16 +31,22 @@ func createNamespace(clientset *kubernetes.Clientset, namespaceName string, nsLa
 	ns := v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: namespaceName, Labels: nsLabels},
 	}
-	log.Infof("Creating namespace %s", ns.Name)
-	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
-	if errors.IsForbidden(err) {
-		log.Fatalf("Authorization error creating namespace %s: %s", ns.Name, err)
-	}
-	if errors.IsAlreadyExists(err) {
-		log.Warnf("Namespace %s already exists", ns.Name)
-	} else if err != nil {
-		return fmt.Errorf("Unexpected error creating namespace: %s", err)
-	}
+	RetryWithExponentialBackOff(func() (done bool, err error) {
+		_, err = clientset.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
+		if errors.IsForbidden(err) {
+			log.Fatalf("Authorization error creating namespace %s: %s", ns.Name, err)
+			return false, err
+		}
+		if errors.IsAlreadyExists(err) {
+			log.Warnf("Namespace %s already exists", ns.Name)
+			return true, err
+		} else if err != nil {
+			log.Errorf("Unexpected error creating namespace %s: %s", ns.Name, err)
+			return false, err
+		}
+		log.Infof("Created namespace: %s", ns.Name)
+		return true, err
+	})
 	return nil
 }
 


### PR DESCRIPTION
### Description
Will prevent hitting issues like:

```
time="2021-03-30 11:00:54" level=error msg="Unexpected error creating namespace: etcdserver: request timed out"
```

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>