### PR TITLE
Fix retry logic in create functions

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -220,14 +220,14 @@ func createRequest(gvr schema.GroupVersionResource, ns string, obj *unstructured
 				return true, err
 			} else if errors.IsAlreadyExists(err) {
 				log.Errorf("%s/%s in namespace %s already exists", obj.GetKind(), obj.GetName(), ns)
-				return true, err
+				return true, nil
 			} else if errors.IsTimeout(err) {
 				log.Errorf("Timeout creating object %s/%s in namespace %s: %s", obj.GetKind(), obj.GetName(), ns, err)
 			} else if err != nil {
 				log.Errorf("Error creating object: %s", err)
 			}
 			log.Error("Retrying object creation")
-			return false, err
+			return false, nil
 		}
 		log.Infof("Created %s/%s in namespace %s", uns.GetKind(), uns.GetName(), ns)
 		return true, err

--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -42,7 +42,7 @@ func createNamespace(clientset *kubernetes.Clientset, namespaceName string, nsLa
 			return true, err
 		} else if err != nil {
 			log.Errorf("Unexpected error creating namespace %s: %s", ns.Name, err)
-			return false, err
+			return false, nil
 		}
 		log.Infof("Created namespace: %s", ns.Name)
 		return true, err


### PR DESCRIPTION
### Description
According to the docs
```
// ExponentialBackoff repeats a condition check with exponential backoff.
//
// It repeatedly checks the condition and then sleeps, using `backoff.Step()`
// to determine the length of the sleep and adjust Duration and Steps.
// Stops and returns as soon as:
// 1. the condition check returns true or an error,
// 2. `backoff.Steps` checks of the condition have been done, or
// 3. a sleep truncated by the cap on duration has been completed.
// In case (1) the returned error is what the condition function returned.
// In all other cases, ErrWaitTimeout is returned.
```


We must return false, nil if we want to retry a function

### Fixes

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>