### PR TITLE
Add more examples locations and clarify documentation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,7 +29,7 @@ Use "kube-burner [command] --help" for more information about a command.
 
 This option is meant to run Kube-burner benchmark, and it supports the these flags:
 
-  - uuid: Benchmark ID. This is esentially an arbitrary string that is used for different purposes along the benchmark. For example, label the objects created by kube-burner as mentioned in the [configuration chapter](/configuration/#Default-labels). You can generate a new uuid in linux with the commands `uuidgen` or `cat /proc/sys/kernel/random/uuid`.
+  - uuid: Benchmark ID. This is esentially an arbitrary string that is used for different purposes along the benchmark. For example, label the objects created by kube-burner as mentioned in the [configuration chapter](configuration/#Default-labels). You can generate a new uuid in linux with the commands `uuidgen` or `cat /proc/sys/kernel/random/uuid`.
   - config: Path or URL to a valid configuration file.
   - log-level: Logging level. Default `info`
   - prometheus-url: Prometheus full URL. i.e. `https://prometheus-k8s-openshift-monitoring.apps.rsevilla.stress.mycluster.example.com`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,7 +49,7 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | errorOnVerify        | Exit with rc 1 before indexing when objects verification fails                   | Boolean | true     | false   |
 
 
-A valid example of a configuration file can be found at [./examples/cfg.yml](https://github.com/cloud-bulldozer/kube-burner/blob/master/examples/cfg.yml)
+A valid example of a configuration file can be found at the [examples](examples) folder.
 
 ## Objects
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,4 +22,4 @@ In case you want to start tinkering with Kube-burner now:
 
 - You can find the binaries in the [releases section of the repository](https://github.com/cloud-bulldozer/kube-burner/releases).
 - There's also a container image available at [quay](https://quay.io/repository/cloud-bulldozer/kube-burner?tab=tags).
-- A valid example of a configuration file can be found at [examples/cfg.yml](https://github.com/cloud-bulldozer/kube-burner/blob/master/examples/cfg.yml)
+- Some valid examples of configuration files can be found in examples [examples](https://github.com/cloud-bulldozer/kube-burner/tree/master/examples) folder of the repository and in a personal [repository](https://github.com/rsevilla87/kube-burner-workloads) which holds several useful workloads.


### PR DESCRIPTION
### Description
Reference external repository with more workloads, and clarify examples location, pointing to a folder rather than a file.

### Fixes
#79 

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>