### PR TITLE
Add -y flag to microdnf

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.fedoraproject.org/fedora-minimal:latest as builder
 
-RUN microdnf install golang make git
+RUN microdnf install -y --nodocs golang make git && microdnf clean all
 COPY . /root/kube-burner
 RUN make clean -C /root/kube-burner && make build -C /root/kube-burner
 


### PR DESCRIPTION
### Description
Seems like latest microdnf builds require now the `-y` flag to behave 100% unattended


Signed-off-by: Raul Sevilla <rsevilla@redhat.com>