### PR TITLE
Deprecate kubeconfig variable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,13 +18,18 @@ In this section is described global job configuration, it holds the following pa
 
 | Option           | Description                                                                                              | Type           | Example        | Default     |
 |------------------|----------------------------------------------------------------------------------------------------------|----------------|----------------|-------------|
-| kubeconfig       | Points to a valid kubeconfig file. Can be omitted if using the KUBECONFIG environment variable, or running from a pod | String  | ~/mykubeconfig | in-cluster |             |
 | writeToFile      | Whether to dump collected metrics to files                                                               | Boolean        | true           | true        |
 | createTarball    | Create metrics tarball, it has no effect if `writeToFile` is not enabled                                 | Boolean        | true           | false       |
 | metricsDirectory | Directory where collected metrics will be dumped into. It will be created if it doesn't exist previously | String         | ./metrics      | ./collected-metrics |
 | measurements     | List of measurements. Detailed in the [measurements section]                                             | List           | -              | []          |
 | indexerConfig    | Holds the indexer configuration. Detailed in the [indexers section]                                      | Object         | -              | -           |
 | requestTimeout   | Client-go request timeout                                                                                | Duration       | 5s             | 15s         |
+
+kube-burner connects to the k8s cluster using the following methods in this order:
+
+- KUBECONFIG environment variable
+- $HOME/.kube/config
+- In-cluster config (Used when kube-burner runs inside a pod)
 
 ## Jobs
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -56,8 +56,6 @@ type IndexerConfig struct {
 
 // GlobalConfig holds the global configuration
 type GlobalConfig struct {
-	// Kubeconfig path to a valid kubeconfig file
-	Kubeconfig string `yaml:"kubeconfig"`
 	// IndexerConfig contains a IndexerConfig definition
 	IndexerConfig IndexerConfig `yaml:"indexerConfig"`
 	// Write prometheus metrics to a file


### PR DESCRIPTION
### Description

Also skipping annoying client-go klog output
```
W0604 10:46:01.769645    8048 client_config.go:559] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
``` 

### Fixes
