### PR TITLE
Fix race condition when a pod status is updated and the channel is still opened

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -42,7 +42,9 @@ check_files () {
     if [[ ! -f $f ]]; then
       log "File ${f} not present"
       rc=1
+      continue
     fi
+    cat $f | jq .
   done
 }
 


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

The first thing we have to do in stop() is closing the channel to stop the informer.

Prevents issues like:

```golang
time="2021-09-22 15:42:50" level=info msg="Stopping measurement: podLatency"                                                                                                                                                                                                    [232/1844]
fatal error: concurrent map iteration and map write                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                          
goroutine 1 [running]:                                                                                                                                                                                                                                                                    
runtime.throw(0x1b797ce, 0x26)                                                                                                                                                                                                                                                            
        /opt/hostedtoolcache/go/1.16.8/x64/src/runtime/panic.go:1117 +0x72 fp=0xc01ffed3b8 sp=0xc01ffed388 pc=0x436352                                                                                                                                                                    
runtime.mapiternext(0xc01ffed488)                                                                                                                                                                                                                                                         
        /opt/hostedtoolcache/go/1.16.8/x64/src/runtime/map.go:858 +0x54c fp=0xc01ffed438 sp=0xc01ffed3b8 pc=0x410b2c
github.com/cloud-bulldozer/kube-burner/pkg/measurements.normalizeMetrics()
        /home/runner/work/kube-burner/kube-burner/pkg/measurements/pod_latency.go:231 +0x87 fp=0xc01ffed6e8 sp=0xc01ffed438 pc=0x17a96e7
github.com/cloud-bulldozer/kube-burner/pkg/measurements.(*podLatency).stop(0xc00047e580, 0x0, 0x0, 0x0)
        /home/runner/work/kube-burner/kube-burner/pkg/measurements/pod_latency.go:201 +0x65 fp=0xc01ffed798 sp=0xc01ffed6e8 pc=0x17a9245
github.com/cloud-bulldozer/kube-burner/pkg/measurements.Stop(0xc00016c200)
        /home/runner/work/kube-burner/kube-burner/pkg/measurements/factory.go:99 +0x173 fp=0xc01ffed8b0 sp=0xc01ffed798 pc=0x17a74b3
main.steps(0x7ffe4f1389b9, 0x24, 0xc000362480, 0x0)
        /home/runner/work/kube-burner/kube-burner/cmd/kube-burner/kube-burner.go:319 +0x42e fp=0xc01ffedbd0 sp=0xc01ffed8b0 pc=0x17c790e
main.initCmd.func1(0xc000446c80, 0xc0000bca50, 0x0, 0xb)
        /home/runner/work/kube-burner/kube-burner/cmd/kube-burner/kube-burner.go:112 +0x1ca fp=0xc01ffedd08 sp=0xc01ffedbd0 pc=0x17c8e6a
github.com/spf13/cobra.(*Command).execute(0xc000446c80, 0xc0000bc9a0, 0xb, 0xb, 0xc000446c80, 0xc0000bc9a0)
        /home/runner/work/kube-burner/kube-burner/vendor/github.com/spf13/cobra/command.go:856 +0x2c2 fp=0xc01ffeddc8 sp=0xc01ffedd08 pc=0x17b8a82
github.com/spf13/cobra.(*Command).ExecuteC(0x2940aa0, 0x0, 0x0, 0x0)
        /home/runner/work/kube-burner/kube-burner/vendor/github.com/spf13/cobra/command.go:960 +0x375 fp=0xc01ffedea8 sp=0xc01ffeddc8 pc=0x17b97b5
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/work/kube-burner/kube-burner/vendor/github.com/spf13/cobra/command.go:897
main.main()
        /home/runner/work/kube-burner/kube-burner/cmd/kube-burner/kube-burner.go:387 +0x2f2 fp=0xc01ffedf88 sp=0xc01ffedea8 pc=0x17c8872
runtime.main()
        /opt/hostedtoolcache/go/1.16.8/x64/src/runtime/proc.go:225 +0x256 fp=0xc01ffedfe0 sp=0xc01ffedf88 pc=0x438b96
runtime.goexit()
        /opt/hostedtoolcache/go/1.16.8/x64/src/runtime/asm_amd64.s:1371 +0x1 fp=0xc01ffedfe8 sp=0xc01ffedfe0 pc=0x46bbc1
```

cc: @jtaleric 
