### PR TITLE
Optimize metric collection in benchmarks with multiple jobs

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -350,8 +350,11 @@ func steps(uuid string, p *prometheus.Prometheus, alertM *alerting.AlertManager)
 		jobList[jobPosition].End = time.Now().UTC()
 		elapsedTime := jobList[jobPosition].End.Sub(jobList[jobPosition].Start).Seconds()
 		log.Infof("Job %s took %.2f seconds", job.Config.Name, elapsedTime)
-		if config.ConfigSpec.GlobalConfig.IndexerConfig.Enabled {
-			err := burner.IndexMetadataInfo(indexer, uuid, elapsedTime, job.Config, jobList[jobPosition].Start)
+	}
+	if config.ConfigSpec.GlobalConfig.IndexerConfig.Enabled {
+		for _, job := range jobList {
+			elapsedTime := job.End.Sub(job.Start).Seconds()
+			err := burner.IndexMetadataInfo(indexer, uuid, elapsedTime, job.Config, job.Start)
 			if err != nil {
 				log.Errorf(err.Error())
 			}

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -347,6 +347,7 @@ func steps(uuid string, p *prometheus.Prometheus, alertM *alerting.AlertManager)
 			log.Infof("Pausing for %v before finishing job", job.Config.JobPause)
 			time.Sleep(job.Config.JobPause)
 		}
+		jobList[jobPosition].End = time.Now().UTC()
 		elapsedTime := jobList[jobPosition].End.Sub(jobList[jobPosition].Start).Seconds()
 		log.Infof("Job %s took %.2f seconds", job.Config.Name, elapsedTime)
 		if config.ConfigSpec.GlobalConfig.IndexerConfig.Enabled {
@@ -355,7 +356,6 @@ func steps(uuid string, p *prometheus.Prometheus, alertM *alerting.AlertManager)
 				log.Errorf(err.Error())
 			}
 		}
-		jobList[jobPosition].End = time.Now().UTC()
 	}
 	if p != nil {
 		log.Infof("Waiting %v extra before scraping prometheus", p.Step*2)

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -347,7 +347,6 @@ func steps(uuid string, p *prometheus.Prometheus, alertM *alerting.AlertManager)
 			log.Infof("Pausing for %v before finishing job", job.Config.JobPause)
 			time.Sleep(job.Config.JobPause)
 		}
-		jobList[jobPosition].End = time.Now().UTC()
 		elapsedTime := jobList[jobPosition].End.Sub(jobList[jobPosition].Start).Seconds()
 		log.Infof("Job %s took %.2f seconds", job.Config.Name, elapsedTime)
 		if config.ConfigSpec.GlobalConfig.IndexerConfig.Enabled {
@@ -356,6 +355,7 @@ func steps(uuid string, p *prometheus.Prometheus, alertM *alerting.AlertManager)
 				log.Errorf(err.Error())
 			}
 		}
+		jobList[jobPosition].End = time.Now().UTC()
 	}
 	if p != nil {
 		log.Infof("Waiting %v extra before scraping prometheus", p.Step*2)

--- a/test/run.sh
+++ b/test/run.sh
@@ -37,7 +37,7 @@ check_running_pods() {
 }
 
 check_files () {
-  for f in collected-metrics/namespaced-prometheusRSS.json collected-metrics/not-namespaced-prometheusRSS.json collected-metrics/namespaced-podLatency.json collected-metrics/namespaced-podLatency-summary.json; do
+  for f in collected-metrics/namespaced-prometheusRSS-${uuid}.json collected-metrics/not-namespaced-prometheusRSS-${uuid}.json collected-metrics/namespaced-podLatency-${uuid}.json collected-metrics/namespaced-podLatency-summary-${uuid}.json; do
     log "Checking file ${f}"
     if [[ ! -f $f ]]; then
       log "File ${f} not present"

--- a/test/run.sh
+++ b/test/run.sh
@@ -37,7 +37,7 @@ check_running_pods() {
 }
 
 check_files () {
-  for f in collected-metrics/namespaced-prometheusRSS-${uuid}.json collected-metrics/not-namespaced-prometheusRSS-${uuid}.json collected-metrics/namespaced-podLatency-${uuid}.json collected-metrics/namespaced-podLatency-summary-${uuid}.json; do
+  for f in collected-metrics/prometheusRSS-${uuid}.json collected-metrics/prometheusRSS-${uuid}.json collected-metrics/namespaced-podLatency.json collected-metrics/namespaced-podLatency-summary.json; do
     log "Checking file ${f}"
     if [[ ! -f $f ]]; then
       log "File ${f} not present"


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
Collect metrics only once and detect to which job belong those metrics with the following logic.
```golang
 for _, job := range jobList {
   // If metric timestamp is lower than job end timestamp, we assume the datapoint belongs to that job
  if val.Timestamp.Time().Before(job.End) {
	  jobName = job.Config.Name
  }
}
```


- Fixes: https://github.com/cloud-bulldozer/kube-burner/issues/127

