### PR TITLE
Truncate namespace

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,6 +118,12 @@ func Parse(c string, jobsRequired bool) error {
 		if err := validateDNS1123(); err != nil {
 			return err
 		}
+		for _, job := range ConfigSpec.Jobs {
+			if len(job.Namespace) > 62 {
+				log.Warnf("Namespace %s length has > 63 characters, truncating it", job.Namespace)
+				job.Namespace = job.Namespace[:62]
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -289,7 +289,9 @@ func (plq *podLatencyQuantiles) setQuantile(quantile float64, qValue int) {
 
 func (p *podLatency) checkThreshold() int {
 	var rc int
-	log.Info("Evaluating latency thresholds")
+	if len(p.config.LatencyThresholds) > 0 {
+		log.Info("Evaluating latency thresholds")
+	}
 	for _, phase := range p.config.LatencyThresholds {
 		for _, pq := range podQuantiles {
 			if phase.ConditionType == pq.(podLatencyQuantiles).QuantileName {


### PR DESCRIPTION
### Description

Truncate namespaces with more than 63 characters

### Fixes

K8s does not allow to create namespaces with more than 63 characters.
