### PR TITLE
Namespaces length should be less than 63 characters to prevent errors…

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -121,7 +121,7 @@ func Parse(c string, jobsRequired bool) error {
 		for _, job := range ConfigSpec.Jobs {
 			if len(job.Namespace) > 62 {
 				log.Warnf("Namespace %s length has > 63 characters, truncating it", job.Namespace)
-				job.Namespace = job.Namespace[:62]
+				job.Namespace = job.Namespace[:57]
 			}
 		}
 	}


### PR DESCRIPTION
… while adding the suffix

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

### Fixes
