### PR TITLE
Wait for measurements initialization before creating objects

### DIFF
--- a/pkg/measurements/factory.go
+++ b/pkg/measurements/factory.go
@@ -16,6 +16,7 @@ package measurements
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/cloud-bulldozer/kube-burner/log"
 	"github.com/cloud-bulldozer/kube-burner/pkg/config"
@@ -35,7 +36,7 @@ type measurementFactory struct {
 }
 
 type measurement interface {
-	start()
+	start(*sync.WaitGroup)
 	stop() (int, error)
 	setConfig(types.Measurement) error
 }
@@ -84,9 +85,10 @@ func SetJobConfig(jobConfig *config.Job) {
 }
 
 // Start starts registered measurements
-func Start() {
+func Start(wg *sync.WaitGroup) {
 	for _, measurement := range factory.createFuncs {
-		go measurement.start()
+		wg.Add(1)
+		go measurement.start(wg)
 	}
 }
 

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cloud-bulldozer/kube-burner/log"
@@ -137,7 +138,8 @@ func (p *podLatency) setConfig(cfg types.Measurement) error {
 }
 
 // Start starts podLatency measurement
-func (p *podLatency) start() {
+func (p *podLatency) start(measurementWg *sync.WaitGroup) {
+	defer measurementWg.Done()
 	podMetrics = make(map[string]podMetric)
 	log.Infof("Creating Pod latency informer for %s", factory.jobConfig.Name)
 	podListWatcher := cache.NewFilteredListWatchFromClient(factory.clientSet.CoreV1().RESTClient(), "pods", v1.NamespaceAll, func(options *metav1.ListOptions) {})

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -58,7 +58,8 @@ func (p *pprof) setConfig(cfg types.Measurement) error {
 	return nil
 }
 
-func (p *pprof) start() {
+func (p *pprof) start(measurementWg *sync.WaitGroup) {
+	defer measurementWg.Done()
 	var wg sync.WaitGroup
 	err := os.MkdirAll(p.directory, 0744)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
Wait for all measurements to be running before creating any object

### Fixes

Fixes a race condition leading to miss some events in small benchmarks.



Running some quick tests with a tiny workload (3 pods):

- Without this patch:

```shell
$ kube-burner init -c kubelet-density.yml 
...
rsevilla@wonderland ~/labs/kube-burner $ grep sche collected-metrics/kubelet-density-podLatency.json   
    "schedulingLatency": 0,                                                                                            
    "schedulingLatency": 0,                                                                                            
    "schedulingLatency": 0,  
$ kube-burner init -c kubelet-density.yml 
...
rsevilla@wonderland ~/labs/kube-burner $ grep sche collected-metrics/kubelet-density-podLatency.json   
    "schedulingLatency": 1,
    "schedulingLatency": 0,
    "schedulingLatency": 0,
rsevilla@wonderland ~/labs/kube-
```

With patch:

```shell
$ kube-burner init -c kubelet-density.yml 
...
$ grep sche collected-metrics/kubelet-density-podLatency.json   
    "schedulingLatency": 5,
    "schedulingLatency": 5,
    "schedulingLatency": 5,
$ kube-burner init -c kubelet-density.yml 
...
$ grep sche collected-metrics/kubelet-density-podLatency.json   
    "schedulingLatency": 10,
    "schedulingLatency": 6,
    "schedulingLatency": 10,

```