### PR TITLE
Add CNI focused kubelet-density variants

### DIFF
--- a/examples/workloads/kubelet-density-cni-networkpolicy/kubelet-density-cni-networkpolicy.yml
+++ b/examples/workloads/kubelet-density-cni-networkpolicy/kubelet-density-cni-networkpolicy.yml
@@ -1,0 +1,50 @@
+---
+global:
+  writeToFile: true
+  metricsDirectory: collected-metrics
+  indexerConfig:
+    enabled: true
+    esServers: [http://elastic-elk.apps.rsevilla.kube-burner.com]
+    insecureSkipVerify: true
+    defaultIndex: kube-burner
+    type: elastic
+  measurements:
+    - name: podLatency
+      esIndex: kube-burner
+
+jobs:
+  - name: deny-all-policy
+    jobIterations: 1
+    qps: 1
+    burst: 1
+    namespacedIterations: false
+    namespace: kubelet-density-cni-networkpolicy
+    jobPause: 1m
+    objects:
+
+      - objectTemplate: templates/deny-all.yml
+        replicas: 1
+
+  - name: kubelet-density-cni-networkpolicy
+    jobIterations: 100
+    qps: 25
+    burst: 25
+    namespacedIterations: false
+    namespace: kubelet-density-cni-networkpolicy
+    waitWhenFinished: true
+    podWait: false
+    preloadImages: true
+    preLoadPeriod: 2m
+    objects:
+
+      - objectTemplate: templates/webserver-deployment.yml
+        replicas: 1
+
+      - objectTemplate: templates/webserver-service.yml
+        replicas: 1
+
+      - objectTemplate: templates/allow-http.yml
+        replicas: 1
+
+      - objectTemplate: templates/curl-deployment.yml
+        replicas: 1

--- a/examples/workloads/kubelet-density-cni-networkpolicy/templates/allow-http.yml
+++ b/examples/workloads/kubelet-density-cni-networkpolicy/templates/allow-http.yml
@@ -1,0 +1,12 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-{{.Replica}}-{{.Iteration}}
+spec:
+  podSelector:
+    matchLabels:
+      name: webserver-{{.Replica}}-{{.Iteration}}
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8080

--- a/examples/workloads/kubelet-density-cni-networkpolicy/templates/curl-deployment.yml
+++ b/examples/workloads/kubelet-density-cni-networkpolicy/templates/curl-deployment.yml
@@ -1,0 +1,40 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: curl-{{.Replica}}-{{.Iteration}}
+spec:
+  template:
+    metadata:
+      labels:
+        name: curl-{{.Replica}}-{{.Iteration}}
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      containers:
+      - name: curlapp
+        image: quay.io/cloud-bulldozer/curl:latest
+        command: ["sleep", "inf"]
+        env:
+        - name: WEBSERVER_HOSTNAME
+          value: webserver-{{.Replica}}-{{.Iteration}}
+        - name: WEBSERVER_PORT
+          value: "8080"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: false
+        readinessProbe:
+          exec:
+            command: 
+              - "/bin/sh"
+              - "-c"
+              - "curl ${WEBSERVER_HOSTNAME}:${WEBSERVER_PORT}"
+          periodSeconds: 1
+      restartPolicy: Always
+  replicas: 1
+  selector:
+    matchLabels:
+      name: curl-{{.Replica}}-{{.Iteration}}
+  triggers:
+  - type: ConfigChange
+  strategy:
+    type: RollingUpdate

--- a/examples/workloads/kubelet-density-cni-networkpolicy/templates/deny-all.yml
+++ b/examples/workloads/kubelet-density-cni-networkpolicy/templates/deny-all.yml
@@ -1,0 +1,7 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: deny-by-default
+spec:
+  podSelector: {}
+  ingress: []

--- a/examples/workloads/kubelet-density-cni-networkpolicy/templates/webserver-deployment.yml
+++ b/examples/workloads/kubelet-density-cni-networkpolicy/templates/webserver-deployment.yml
@@ -1,0 +1,30 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: webserver-{{.Replica}}-{{.Iteration}}
+spec:
+  template:
+    metadata:
+      labels:
+        name: webserver-{{.Replica}}-{{.Iteration}}
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      containers:
+      - name: webserver
+        image: quay.io/cloud-bulldozer/sampleapp:latest
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: false
+      restartPolicy: Always
+  replicas: 1
+  selector:
+    matchLabels:
+      name: webserver-{{.Replica}}-{{.Iteration}}
+  triggers:
+  - type: ConfigChange
+  strategy:
+    type: RollingUpdate

--- a/examples/workloads/kubelet-density-cni-networkpolicy/templates/webserver-service.yml
+++ b/examples/workloads/kubelet-density-cni-networkpolicy/templates/webserver-service.yml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: webserver-{{.Replica}}-{{.Iteration}}
+spec:
+  selector:
+    name: webserver-{{.Replica}}-{{.Iteration}}
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  type: ClusterIP

--- a/examples/workloads/kubelet-density-cni/kubelet-density-cni.yml
+++ b/examples/workloads/kubelet-density-cni/kubelet-density-cni.yml
@@ -1,0 +1,35 @@
+---
+global:
+  writeToFile: true
+  metricsDirectory: collected-metrics
+  indexerConfig:
+    enabled: true
+    esServers: [http://elastic-elk.apps.rsevilla.kube-burner.com]
+    insecureSkipVerify: true
+    defaultIndex: kube-burner
+    type: elastic
+  measurements:
+    - name: podLatency
+      esIndex: kube-burner
+
+jobs:
+  - name: kubelet-density-cni
+    jobIterations: 100
+    qps: 25
+    burst: 25
+    namespacedIterations: false
+    namespace: kubelet-density-cni
+    waitWhenFinished: true
+    podWait: false
+    preloadImages: true
+    preLoadPeriod: 2m
+    objects:
+
+      - objectTemplate: templates/webserver-deployment.yml
+        replicas: 1
+
+      - objectTemplate: templates/webserver-service.yml
+        replicas: 1
+
+      - objectTemplate: templates/curl-deployment.yml
+        replicas: 1

--- a/examples/workloads/kubelet-density-cni/templates/curl-deployment.yml
+++ b/examples/workloads/kubelet-density-cni/templates/curl-deployment.yml
@@ -1,0 +1,40 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: curl-{{.Replica}}-{{.Iteration}}
+spec:
+  template:
+    metadata:
+      labels:
+        name: curl-{{.Replica}}-{{.Iteration}}
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      containers:
+      - name: curlapp
+        image: quay.io/cloud-bulldozer/curl:latest
+        command: ["sleep", "inf"]
+        env:
+        - name: WEBSERVER_HOSTNAME
+          value: webserver-{{.Replica}}-{{.Iteration}}
+        - name: WEBSERVER_PORT
+          value: "8080"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: false
+        readinessProbe:
+          exec:
+            command: 
+              - "/bin/sh"
+              - "-c"
+              - "curl ${WEBSERVER_HOSTNAME}:${WEBSERVER_PORT}"
+          periodSeconds: 1
+      restartPolicy: Always
+  replicas: 1
+  selector:
+    matchLabels:
+      name: curl-{{.Replica}}-{{.Iteration}}
+  triggers:
+  - type: ConfigChange
+  strategy:
+    type: RollingUpdate

--- a/examples/workloads/kubelet-density-cni/templates/webserver-deployment.yml
+++ b/examples/workloads/kubelet-density-cni/templates/webserver-deployment.yml
@@ -1,0 +1,30 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: webserver-{{.Replica}}-{{.Iteration}}
+spec:
+  template:
+    metadata:
+      labels:
+        name: webserver-{{.Replica}}-{{.Iteration}}
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      containers:
+      - name: webserver
+        image: quay.io/cloud-bulldozer/sampleapp:latest
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: false
+      restartPolicy: Always
+  replicas: 1
+  selector:
+    matchLabels:
+      name: webserver-{{.Replica}}-{{.Iteration}}
+  triggers:
+  - type: ConfigChange
+  strategy:
+    type: RollingUpdate

--- a/examples/workloads/kubelet-density-cni/templates/webserver-service.yml
+++ b/examples/workloads/kubelet-density-cni/templates/webserver-service.yml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: webserver-{{.Replica}}-{{.Iteration}}
+spec:
+  selector:
+    name: webserver-{{.Replica}}-{{.Iteration}}
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  type: ClusterIP


### PR DESCRIPTION
This uses a curl for the readinessprobe of the client pod which can
help measure CNI latency. We also no longer use a postgres
pod on the server side - that is replaced by a simple node.js
app. Also adds networkpolicy.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
