### PR TITLE
Pre load job images

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,8 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | objects              | List of objects the job will create. Detailed on the [objects section](#objects) | List    | -        | []      |
 | verifyObjects        | Verify object count after running each job. Return code will be 1 if failed      | Boolean | true     | true    |
 | errorOnVerify        | Exit with rc 1 before indexing when objects verification fails                   | Boolean | true     | false   |
+| preloadImages        | Kube-burner will create a DS before triggering the job to pull all the images of the job | Boolean | true | false |
+| preLoadPeriod        | How long to wait for the preload daemonset                                       | Duration | 2m      | 1m      |
 
 
 Examples of valid configuration files can be found at the [examples folder](https://github.com/cloud-bulldozer/kube-burner/tree/master/examples).

--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -73,7 +73,7 @@ func getJobImages(job Executor) ([]string, error) {
 
 func createDS(imageList []string, jobName string) error {
 	var containerList []corev1.Container
-	dsName := fmt.Sprintf("prepull-%s", jobName)
+	dsName := fmt.Sprintf("preload-%s", jobName)
 	if err := createNamespace(ClientSet, preLoadNs, map[string]string{}); err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -72,13 +72,13 @@ func getJobImages(job Executor) ([]string, error) {
 }
 
 func createDSs(imageList []string, jobName string) error {
-	dsName := fmt.Sprintf("preload-%s", jobName)
 	if err := createNamespace(ClientSet, preLoadNs, map[string]string{}); err != nil {
 		log.Fatal(err)
 	}
-	for _, image := range imageList {
+	for i, image := range imageList {
+		dsName := fmt.Sprintf("preload-%d", i)
 		container := corev1.Container{
-			Name:            fmt.Sprintf("foobar"),
+			Name:            "foobar",
 			ImagePullPolicy: corev1.PullAlways,
 			Image:           image,
 		}

--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -32,7 +32,7 @@ func PreLoadImages(job Executor) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = createDSs(imageList, job.Config.Name)
+	err = createDSs(imageList)
 	if err != nil {
 		log.Fatalf("Pre-load: %v", err)
 	}
@@ -71,7 +71,7 @@ func getJobImages(job Executor) ([]string, error) {
 	return imageList, nil
 }
 
-func createDSs(imageList []string, jobName string) error {
+func createDSs(imageList []string) error {
 	if err := createNamespace(ClientSet, preLoadNs, map[string]string{}); err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -27,18 +27,18 @@ type NestedPod struct {
 }
 
 func PreLoadImages(job Executor) {
-	log.Info("Pre-pulling: images from job ", job.Config.Name)
+	log.Info("Pre-load: images from job ", job.Config.Name)
 	imageList, err := getJobImages(job)
 	if err != nil {
 		log.Fatal(err)
 	}
 	err = createDS(imageList, job.Config.Name)
 	if err != nil {
-		log.Fatalf("Pre-pulling: %v", err)
+		log.Fatalf("Pre-load: %v", err)
 	}
-	log.Infof("Pre-pulling: Sleeping for %v", job.Config.PreLoadPeriod)
+	log.Infof("Pre-load: Sleeping for %v", job.Config.PreLoadPeriod)
 	time.Sleep(job.Config.PreLoadPeriod)
-	log.Info("Pre-pulling: Deleting namespace")
+	log.Infof("Pre-load: Deleting namespace %s", preLoadNs)
 	CleanupNamespaces(ClientSet, v1.ListOptions{LabelSelector: fmt.Sprintf("kubernetes.io/metadata.name=%s", preLoadNs)})
 }
 
@@ -114,7 +114,7 @@ func createDS(imageList []string, jobName string) error {
 			},
 		},
 	}
-	log.Infof("Pre-pulling: Creating DaemonSet %s in namespace %s", dsName, preLoadNs)
+	log.Infof("Pre-load: Creating DaemonSet %s in namespace %s", dsName, preLoadNs)
 	_, err := ClientSet.AppsV1().DaemonSets(preLoadNs).Create(context.TODO(), &ds, v1.CreateOptions{})
 	if err != nil {
 		return err

--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -1,0 +1,123 @@
+package burner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cloud-bulldozer/kube-burner/log"
+	"github.com/cloud-bulldozer/kube-burner/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var preLoadNs string = "kube-burner"
+
+// NestedPod represents a pod nested in a higher level object such as deployment or a daemonset
+type NestedPod struct {
+	// Spec represents the object spec
+	Spec struct {
+		Template struct {
+			corev1.PodSpec `json:"spec"`
+		} `json:"template"`
+	} `json:"spec"`
+}
+
+func PreLoadImages(job Executor) {
+	log.Info("Pre-pulling: images from job ", job.Config.Name)
+	imageList, err := getJobImages(job)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = createDS(imageList, job.Config.Name)
+	if err != nil {
+		log.Fatalf("Pre-pulling: %v", err)
+	}
+	log.Infof("Pre-pulling: Sleeping for %v", job.Config.PreLoadPeriod)
+	time.Sleep(job.Config.PreLoadPeriod)
+	log.Info("Pre-pulling: Deleting namespace")
+	CleanupNamespaces(ClientSet, v1.ListOptions{LabelSelector: fmt.Sprintf("kubernetes.io/metadata.name=%s", preLoadNs)})
+}
+
+func getJobImages(job Executor) ([]string, error) {
+	var imageList []string
+	var unstructuredObject unstructured.Unstructured
+	for _, object := range job.objects {
+		renderedObj, err := util.RenderTemplate(object.objectSpec, object.inputVars, util.MissingKeyZero)
+		if err != nil {
+			return imageList, err
+		}
+		yamlToUnstructured(renderedObj, &unstructuredObject)
+		switch unstructuredObject.GetKind() {
+		case "Deployment", "DaemonSet", "ReplicaSet", "Job":
+			var pod NestedPod
+			runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObject.UnstructuredContent(), &pod)
+			for _, i := range pod.Spec.Template.Containers {
+				imageList = append(imageList, i.Image)
+			}
+		case "Pod":
+			var pod corev1.Pod
+			runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObject.UnstructuredContent(), &pod)
+			for _, i := range pod.Spec.Containers {
+				if i.Image != "" {
+					imageList = append(imageList, i.Image)
+				}
+			}
+		}
+	}
+	return imageList, nil
+}
+
+func createDS(imageList []string, jobName string) error {
+	var containerList []corev1.Container
+	dsName := fmt.Sprintf("prepull-%s", jobName)
+	if err := createNamespace(ClientSet, preLoadNs, map[string]string{}); err != nil {
+		log.Fatal(err)
+	}
+	for i, image := range imageList {
+		container := corev1.Container{
+			Name:            fmt.Sprintf("container-%d", i),
+			ImagePullPolicy: corev1.PullAlways,
+			Image:           image,
+		}
+		containerList = append(containerList, container)
+	}
+	ds := appsv1.DaemonSet{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: dsName,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &v1.LabelSelector{
+				MatchLabels: map[string]string{"app": dsName},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"app": dsName},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: containerList,
+					// Only Always restart policy is supported
+					Containers: []corev1.Container{
+						{
+							Name:  "sleep",
+							Image: "gcr.io/google_containers/pause-amd64:3.0",
+						},
+					},
+				},
+			},
+		},
+	}
+	log.Infof("Pre-pulling: Creating DaemonSet %s in namespace %s", dsName, preLoadNs)
+	_, err := ClientSet.AppsV1().DaemonSets(preLoadNs).Create(context.TODO(), &ds, v1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/burner/utils.go
+++ b/pkg/burner/utils.go
@@ -64,7 +64,7 @@ func yamlToUnstructured(y []byte, uns *unstructured.Unstructured) (runtime.Objec
 // Cleanup deletes old namespaces from a given job
 func (ex *Executor) Cleanup() {
 	if ex.Config.Cleanup {
-		CleanupNamespaces(ClientSet, ex.selector)
+		CleanupNamespaces(ClientSet, ex.selector.ListOptions)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,8 @@ func (j *Job) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		JobType:              CreationJob,
 		WaitForDeletion:      true,
 		MaxWaitTimeout:       3 * time.Hour,
+		PreLoadImages:        false,
+		PreLoadPeriod:        1 * time.Minute,
 	}
 	if err := unmarshal(&raw); err != nil {
 		return err

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -126,4 +126,8 @@ type Job struct {
 	VerifyObjects bool `yaml:"verifyObjects" json:"verifyObjects"`
 	// ErrorOnVerify exit when verification fails
 	ErrorOnVerify bool `yaml:"errorOnVerify" json:"errorOnVerify"`
+	// PreLoadImages enables pulling all images before running the job
+	PreLoadImages bool `yaml:"preLoadImages" json:"preLoadImages"`
+	// PreLoadPeriod determines the duration of the prepull stage
+	PreLoadPeriod time.Duration `yaml:"preLoadPeriod" json:"preLoadPeriod"`
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -128,6 +128,6 @@ type Job struct {
 	ErrorOnVerify bool `yaml:"errorOnVerify" json:"errorOnVerify"`
 	// PreLoadImages enables pulling all images before running the job
 	PreLoadImages bool `yaml:"preLoadImages" json:"preLoadImages"`
-	// PreLoadPeriod determines the duration of the prepull stage
+	// PreLoadPeriod determines the duration of the preload stage
 	PreLoadPeriod time.Duration `yaml:"preLoadPeriod" json:"preLoadPeriod"`
 }

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -30,6 +30,7 @@ type templateOption string
 
 const (
 	MissingKeyError templateOption = "missingkey=error"
+	MissingKeyZero  templateOption = "missingkey=zero"
 )
 
 func init() {

--- a/test/kube-burner.yml
+++ b/test/kube-burner.yml
@@ -17,6 +17,8 @@ jobs:
     qps: {{ .QPS }}
     burst: {{ .BURST }}
     namespacedIterations: true
+    preLoadImages: true
+    preLoadPeriod: 30s
     cleanup: true
     namespace: namespaced
     podWait: false


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Pre load images implementation, this feature can help us to determine Pod latencies with higher precision. 

It follows the workflow below:

- Job-1 (ImagePreload is true)
  -  Extract images from the job's object templates. Currently supported objects are Deployments, DaemonSets ReplicaSets, Jobs and Pods
  - Create the kube-burner namespace
  - Create DaemonSet(s) in the previous namespace (1 replica of these pods will be scheduled to all nodes of the cluster) using the extracted images, these DaemonSets consists of a initContainer one of the  the images extracted from the templates and a container using a pause image. The initContainer trick is used to prevent the RestartPolicy "Always" from the DS to generate too much noise in the nodes.
  - Wait/sleep for `PreLoadPeriod`, which defaults to 1 minute. (Make kube-burner sleep is not very fancy, however there's no way to ensure the DaemonSet will be in ready status as we don't know what images the benchmark is using)
  - Delete the kube-burner namespace and wait for it to be deleted
- As of this moment the job continues it's normal behavior.
- Job-N
  - ...
 
FYI: @josecastillolema @mohit-sheth @jtaleric 

### Fixes
- #131 