### PR TITLE
Fix incorrect template for Patch api-intensive example

### DIFF
--- a/examples/workloads/api-intensive/api-intensive.yml
+++ b/examples/workloads/api-intensive/api-intensive.yml
@@ -50,7 +50,7 @@ jobs:
         patchType: "application/apply-patch+yaml"
         apiVersion: apps/v1
       - kind: Deployment
-        objectTemplate: templates/deployment_patch_add_pod_3.yaml
+        objectTemplate: templates/deployment_patch_add_label.yaml
         labelSelector: {kube-burner-job: api-intensive}
         patchType: "application/strategic-merge-patch+json"
         apiVersion: apps/v1


### PR DESCRIPTION
### Description
I accidentally selected a different template for a patch example in the api-intensive config than I added to the folder. This fixes that.

### Fixes
Fixes #160 