### PR TITLE
Preload namespace name

### DIFF
--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-var preLoadNs string = "kube-burner"
+var preLoadNs string = "preload-kube-burner"
 
 // NestedPod represents a pod nested in a higher level object such as deployment or a daemonset
 type NestedPod struct {


### PR DESCRIPTION
Update to preload-kube-burner to prevent conflicts in OCP managed-services
deployments

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

### Fixes
