### PR TITLE
Enable thanos scraping

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -74,7 +74,7 @@ func NewPrometheusClient(url, token, username, password, uuid string, tlsVerify 
 }
 
 func (p *Prometheus) verifyConnection() error {
-	_, err := p.api.Config(context.TODO())
+	_, err := p.api.Runtimeinfo(context.TODO())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

Thanos does not expose the config endpoint, replacing it by runtimeinfo


### Fixes
