### PR TITLE
Reduce timeoutSeconds for startupProbe

### DIFF
--- a/examples/workloads/kubelet-density-cni-networkpolicy/templates/curl-deployment.yml
+++ b/examples/workloads/kubelet-density-cni-networkpolicy/templates/curl-deployment.yml
@@ -29,7 +29,7 @@ spec:
               - "-c"
               - "curl ${WEBSERVER_HOSTNAME}:${WEBSERVER_PORT}"
           periodSeconds: 1
-          timeoutSeconds: 60
+          timeoutSeconds: 1
           failureThreshold: 600
       restartPolicy: Always
   replicas: 1

--- a/examples/workloads/kubelet-density-cni/templates/curl-deployment.yml
+++ b/examples/workloads/kubelet-density-cni/templates/curl-deployment.yml
@@ -29,7 +29,7 @@ spec:
               - "-c"
               - "curl ${WEBSERVER_HOSTNAME}:${WEBSERVER_PORT}"
           periodSeconds: 1
-          timeoutSeconds: 60
+          timeoutSeconds: 1
           failureThreshold: 600
       restartPolicy: Always
   replicas: 1


### PR DESCRIPTION
Amend kubelet-density-cni and kubelet-density-cni-networkpolicy
examples for finer granularity.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
