### PR TITLE
Set namespace PSS to privileged

### DIFF
--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -27,6 +27,7 @@ import (
 )
 
 func createNamespace(clientset *kubernetes.Clientset, namespaceName string, nsLabels map[string]string) error {
+	nsLabels["pod-security.kubernetes.io/warn"] = "privileged"
 	ns := v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: namespaceName, Labels: nsLabels},
 	}


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Will prevent warnings from the API like:
 ```
Error from server (Forbidden): error when creating "pod.yml": pods "kubelet-density" is forbidden: violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "kubelet-density" must set securityContext.allowPriv
ilegeEscalation=false), unrestricted capabilities (container "kubelet-density" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "kubelet-density" must set securityContext.runAsNonRoot=true), secc
ompProfile (pod or container "kubelet-density" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

cc: @qiliRedHat


