### PR TITLE
Set RC to 1 when object verification fails rather than exit

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -131,7 +131,7 @@ func (ex *Executor) RunCreateJob() {
 		// Wait for all replicaHandlers to finish before moving forward to next iteration
 		wg.Wait()
 		if ex.Config.PodWait {
-			log.Infof("Waiting %s all job actions to be completed", ex.Config.MaxWaitTimeout)
+			log.Infof("Waiting up to %s all job actions to be completed", ex.Config.MaxWaitTimeout)
 			log.Debugf("Waiting for actions in namespace %v to be completed", ns)
 			ex.waitForObjects(ns)
 		}
@@ -142,7 +142,7 @@ func (ex *Executor) RunCreateJob() {
 	}
 	if ex.Config.WaitWhenFinished && !ex.Config.PodWait {
 		wg.Wait()
-		log.Infof("Waiting %s for actions to be completed", ex.Config.MaxWaitTimeout)
+		log.Infof("Waiting up to %s for actions to be completed", ex.Config.MaxWaitTimeout)
 		// This semaphore is used to limit the maximum number of concurrent goroutines
 		sem := make(chan int, int(ex.Config.QPS)/2)
 		if RestConfig.QPS < 2 {


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

With the previous implementation, when the object verification failed and errorOnVerify was true, kube-burner exited instantaneously. With this new approach, kube-burner will set RC to 1, and will go forward to metrics indexing.

## Fixes

Recent OCP payloads based in k8s 1.24 are failing and skipping metrics indexing due to a API issue leading to fail object listing using labelSelectors (mechanism used by kube-burner in object verification under the hood): 
https://bugzilla.redhat.com/show_bug.cgi?id=2094012