### PR TITLE
Custom labels to namespaces

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,7 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | errorOnVerify        | Set RC to 1 when objects verification fails                                      | Boolean | true     | false   |
 | preLoadImages        | Kube-burner will create a DS before triggering the job to pull all the images of the job | Boolean | true | false |
 | preLoadPeriod        | How long to wait for the preload daemonset                                       | Duration | 2m      | 1m      |
+| namespaceLabels      | Add custom labels to the namespaces created by kube-burner                       | Object   | {"foo": "bar"} | - |
 
 
 Examples of valid configuration files can be found at the [examples folder](https://github.com/cloud-bulldozer/kube-burner/tree/master/examples).

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -106,9 +106,11 @@ func (ex *Executor) RunCreateJob() {
 	}
 	dynamicClient = dynamic.NewForConfigOrDie(RestConfig)
 	log.Infof("Running job %s", ex.Config.Name)
+	for label, value := range ex.Config.NamespaceLabels {
+		nsLabels[label] = value
+	}
 	if ex.nsObjects && !ex.Config.NamespacedIterations {
-		ns = ex.Config.Namespace
-		nsLabels["name"] = ns
+		nsLabels["name"] = ex.Config.Namespace
 		if err = createNamespace(ClientSet, ns, nsLabels); err != nil {
 			log.Fatal(err.Error())
 		}

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -110,7 +110,8 @@ func (ex *Executor) RunCreateJob() {
 		nsLabels[label] = value
 	}
 	if ex.nsObjects && !ex.Config.NamespacedIterations {
-		nsLabels["name"] = ex.Config.Namespace
+		ns = ex.Config.Namespace
+		nsLabels["name"] = ns
 		if err = createNamespace(ClientSet, ns, nsLabels); err != nil {
 			log.Fatal(err.Error())
 		}

--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -45,7 +45,7 @@ func createNamespace(clientset *kubernetes.Clientset, namespaceName string, nsLa
 			}
 			return true, nil
 		} else if err != nil {
-			log.Errorf("unexpected error creating namespace %s", ns.Name)
+			log.Errorf("unexpected error creating namespace %s: %v", namespaceName, err)
 			return false, nil
 		}
 		log.Debugf("Created namespace: %s", ns.Name)

--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -32,7 +32,7 @@ func PreLoadImages(job Executor) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = createDSs(imageList)
+	err = createDSs(imageList, job.Config.NamespaceLabels)
 	if err != nil {
 		log.Fatalf("Pre-load: %v", err)
 	}
@@ -71,8 +71,14 @@ func getJobImages(job Executor) ([]string, error) {
 	return imageList, nil
 }
 
-func createDSs(imageList []string) error {
-	if err := createNamespace(ClientSet, preLoadNs, map[string]string{"kube-burner-preload": "true"}); err != nil {
+func createDSs(imageList []string, namespaceLabels map[string]string) error {
+	nsLabels := map[string]string{
+		"kube-burner-preload": "true",
+	}
+	for label, value := range namespaceLabels {
+		nsLabels[label] = value
+	}
+	if err := createNamespace(ClientSet, preLoadNs, nsLabels); err != nil {
 		log.Fatal(err)
 	}
 	for i, image := range imageList {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -136,4 +136,6 @@ type Job struct {
 	PreLoadImages bool `yaml:"preLoadImages" json:"preLoadImages"`
 	// PreLoadPeriod determines the duration of the preload stage
 	PreLoadPeriod time.Duration `yaml:"preLoadPeriod" json:"preLoadPeriod"`
+	// NamespaceLabels add custom labels to namespaces created by kube-burner
+	NamespaceLabels map[string]string `yaml:"namespaceLabels" json:"namespaceLabels,omitempty"`
 }

--- a/test/kube-burner.yml
+++ b/test/kube-burner.yml
@@ -27,6 +27,9 @@ jobs:
     errorOnVerify: true
     jobIterationDelay: 10s
     maxWaitTimeout: 2m
+    namespaceLabels:
+      foo: bar
+      complex.label/test: true
     objects:
     
     - objectTemplate: objectTemplates/deployment.yml


### PR DESCRIPTION
Due to recent changes in the pod security standards in OpenShift we
should be able to provide the option to add custom labels to namespaces created by
kube-buner in order to bypass those policies in our performance
benchmarks

Context -> https://github.com/cloud-bulldozer/e2e-benchmarking/issues/436

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

### Fixes
