### PR TITLE
Adding privileged namespaces by default to namespaces

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -90,6 +90,11 @@ func (ex *Executor) RunCreateJob() {
 	nsLabels := map[string]string{
 		"kube-burner-job":  ex.Config.Name,
 		"kube-burner-uuid": ex.uuid,
+		"pod-security.kubernetes.io/enforce": "privileged",
+		"pod-security.kubernetes.io/enforce-version": "latest", 
+		"pod-security.kubernetes.io/audit": "privileged",
+		"pod-security.kubernetes.io/warn": "privileged",
+		"security.openshift.io/scc.podSecurityLabelSync": "false",
 	}
 	var wg sync.WaitGroup
 	var ns string

--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -74,10 +74,18 @@ func getJobImages(job Executor) ([]string, error) {
 func createDSs(imageList []string, namespaceLabels map[string]string) error {
 	nsLabels := map[string]string{
 		"kube-burner-preload": "true",
+		"pod-security.kubernetes.io/enforce": "privileged",
+		"pod-security.kubernetes.io/enforce-version": "latest", 
+		"pod-security.kubernetes.io/audit": "privileged",
+		"pod-security.kubernetes.io/warn": "privileged",
+		"security.openshift.io/scc.podSecurityLabelSync": "false",
+
 	}
+	
 	for label, value := range namespaceLabels {
 		nsLabels[label] = value
 	}
+	
 	if err := createNamespace(ClientSet, preLoadNs, nsLabels); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
### Description
This is adding all necessary namespace labels to any created namespace by kube-burner
Left the setting of namespace labels from [PR](https://github.com/cloud-bulldozer/kube-burner/pull/184) to after the setting I do so we can overwrite if needed

### Fixes
PSS Issues in 4.12
