### PR TITLE
Reset latency slices when stopping measurement

### DIFF
--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -161,6 +161,9 @@ func (p *podLatency) stop() (int, error) {
 		pq := q.(metrics.LatencyQuantiles)
 		log.Infof("%s: %s 50th: %v 99th: %v max: %v avg: %v", factory.jobConfig.Name, pq.QuantileName, pq.P50, pq.P99, pq.Max, pq.Avg)
 	}
+	// Reset latency slices, required in multi-job benchmarks
+	p.latencyQuantiles = nil
+	p.normLatencies = nil
 	return rc, nil
 }
 

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -376,6 +376,9 @@ func (p *vmiLatency) stop() (int, error) {
 	if kubeburnerCfg.IndexerConfig.Enabled {
 		p.index()
 	}
+	// Reset latency slices, required in multi-job benchmarks
+	p.latencyQuantiles = nil
+	p.normLatencies = nil
 	return rc, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

We need to reset pod/vmi latency slices when the measurement is stopped to avoid indexing/writing data from previous jobs

- Fixes part of #181
