### PR TITLE
Add churn ability

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -15,9 +15,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"sync"
@@ -36,7 +34,6 @@ import (
 	uid "github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
@@ -315,7 +312,7 @@ func steps(uuid string, p *prometheus.Prometheus, alertM *alerting.AlertManager)
 			log.Fatal(err.Error())
 		}
 	}
-	clientSet, restConfig, err := config.GetClientSet(0, 0)
+	_, restConfig, err := config.GetClientSet(0, 0)
 	if err != nil {
 		log.Fatalf("Error creating k8s clientSet: %s", err)
 	}
@@ -346,62 +343,7 @@ func steps(uuid string, p *prometheus.Prometheus, alertM *alerting.AlertManager)
 				log.Error(errMsg)
 			}
 			if job.Config.Churn {
-				log.Info("Starting to Churn job")
-				log.Infof("Churn Duration: %v", job.Config.ChurnDuration)
-				log.Infof("Churn Percent: %v", job.Config.ChurnPercent)
-				log.Infof("Churn Delay: %v", job.Config.ChurnDelay)
-				// Determine the number of job iterations to churn (min 1)
-				numToChurn := int((float64(job.Config.ChurnPercent) * float64(job.Config.JobIterations)) / float64(100))
-				if numToChurn < 1 {
-					numToChurn = 1
-				}
-				// Create timer for the churn duration
-				cTimer := time.NewTimer(job.Config.ChurnDuration)
-
-				rand.Seed(time.Now().UnixNano())
-				// Patch to label namespaces for deletion
-				delPatch := []byte(`[{"op":"add","path":"/metadata/labels","value":{"CHURNDELETE":"DELETE"}}]`)
-
-			churnComplete:
-				for {
-					select {
-					case <-cTimer.C:
-						log.Info("Churn job complete")
-						break churnComplete
-					default:
-						log.Debug("Next churn loop")
-					}
-					// Max amount of churn is 100% of namespaces
-					randStart := 1
-					if job.Config.JobIterations-numToChurn+1 > 0 {
-						randStart = rand.Intn(job.Config.JobIterations-numToChurn+1) + 1
-					} else {
-						numToChurn = job.Config.JobIterations
-					}
-
-					// if namespaced workload delete numToChurn namespaces
-					if job.Config.NamespacedIterations {
-						// delete numToChurn namespaces starting at randStart
-						for i := randStart; i < numToChurn+randStart; i++ {
-							nsName := fmt.Sprintf("%s-%d", job.Config.Namespace, i)
-							// Label namespaces to be deleted
-							_, err = clientSet.CoreV1().Namespaces().Patch(context.TODO(), nsName, types.JSONPatchType, delPatch, v1.PatchOptions{})
-							if err != nil {
-								log.Errorf("Error patching namespace %s. Error: %v", nsName, err)
-							}
-						}
-						listOptions := v1.ListOptions{LabelSelector: "CHURNDELETE=DELETE"}
-						// Delete namespaces based on the label we added
-						burner.CleanupNamespaces(clientSet, listOptions)
-					} else {
-						// single namespace TBD
-						log.Warn("Currently only Churning of namespace based workloads are supported")
-					}
-					log.Info("Re-creating deleted objects")
-					// Re-create objects that were deleted
-					job.RunCreateJob(randStart, numToChurn+randStart-1)
-					time.Sleep(job.Config.ChurnDelay)
-				}
+				job.RunCreateJobWithChurn()
 			}
 			// We stop and index measurements per job
 			if measurements.Stop() == 1 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,8 +55,12 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | verifyObjects        | Verify object count after running each job                                       | Boolean | true     | true    |
 | errorOnVerify        | Set RC to 1 when objects verification fails                                      | Boolean | true     | false   |
 | preLoadImages        | Kube-burner will create a DS before triggering the job to pull all the images of the job | Boolean | true | false |
-| preLoadPeriod        | How long to wait for the preload daemonset                                       | Duration | 2m      | 1m      |
-| namespaceLabels      | Add custom labels to the namespaces created by kube-burner                       | Object   | {"foo": "bar"} | - |
+| preLoadPeriod        | How long to wait for the preload daemonset                                       | Duration| 2m      | 1m      |
+| namespaceLabels      | Add custom labels to the namespaces created by kube-burner                       | Object  | {"foo": "bar"} | - |
+| churn                | Churn the workload. Only supports namespace based workloads                      | Boolean | true | false |
+| churnPercent         | Percentage of the jobIterations to churn each period                             | Integer | 10 | 10 |
+| churnDuration        | Length of time that the job is churned for                                       | Duration| 10m | 1h |
+| churnDelay           | Length of time to wait between each churn period                                 | Duration| 10m | 5m |
 
 
 Examples of valid configuration files can be found at the [examples folder](https://github.com/cloud-bulldozer/kube-burner/tree/master/examples).
@@ -158,6 +162,33 @@ This job type supports the some of the same parameters as the create job type:
 - qps
 - burst
 - jobPause
+
+## Churning Jobs
+
+Churn or the deletion and re-creation of objects, is supported for namespace based jobs only. This ocurs after the job has completed
+but prior to uploading metrics, if applicable. It deletes a percentage of contiguous namespaces randomly chosen and re-creates them
+with all of the appropriate objects. It will then wait for a specified delay (or none if set to 0) before deleting and recreating the
+next randomly chosen set. This cycle continues until the churn duration has passed.
+
+An example implementation that would churn 20% of the 100 job iterations for 2 hours with no delay between sets:
+
+```yaml
+jobs:
+  - name: cluster-density
+    jobIterations: 100
+    namespacedIterations: true
+    namespace: churning
+    churn: true
+    churnPercent: 20
+    churnDuration: 2h
+    churnDelay: 0s
+  objects:
+  - objectTemplate: deployment.yml
+    replicas: 10
+
+  - objectTemplate: service.yml
+    replicas: 10
+```
 
 ## Injected variables
 

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -86,7 +86,7 @@ func setupCreateJob(jobConfig config.Job) Executor {
 }
 
 // RunCreateJob executes a creation job
-func (ex *Executor) RunCreateJob() {
+func (ex *Executor) RunCreateJob(iterationStart int, iterationEnd int) {
 	nsLabels := map[string]string{
 		"kube-burner-job":  ex.Config.Name,
 		"kube-burner-uuid": ex.uuid,
@@ -117,7 +117,7 @@ func (ex *Executor) RunCreateJob() {
 		}
 	}
 	t0 := time.Now().Round(time.Second)
-	for i := 1; i <= ex.Config.JobIterations; i++ {
+	for i := iterationStart; i <= iterationEnd; i++ {
 		log.Debugf("Creating object replicas from iteration %d", i)
 		if ex.nsObjects && ex.Config.NamespacedIterations {
 			ns = fmt.Sprintf("%s-%d", ex.Config.Namespace, i)
@@ -151,7 +151,7 @@ func (ex *Executor) RunCreateJob() {
 		if RestConfig.QPS < 2 {
 			sem = make(chan int, int(rest.DefaultQPS)/2)
 		}
-		for i := 1; i <= ex.Config.JobIterations; i++ {
+		for i := iterationStart; i <= iterationEnd; i++ {
 			if ex.Config.NamespacedIterations {
 				ns = fmt.Sprintf("%s-%d", ex.Config.Namespace, i)
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,6 +144,9 @@ func Parse(c string, jobsRequired bool) error {
 				log.Warnf("Namespace %s length has > 63 characters, truncating it", job.Namespace)
 				job.Namespace = job.Namespace[:57]
 			}
+			if !job.NamespacedIterations && job.Churn {
+				log.Fatal("Error: Cannot have Churn enabled without Namespaced Iterations also enabled")
+			}
 		}
 	}
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,6 +96,10 @@ func (j *Job) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		MaxWaitTimeout:       3 * time.Hour,
 		PreLoadImages:        false,
 		PreLoadPeriod:        1 * time.Minute,
+		Churn:                false,
+		ChurnPercent:         10,
+		ChurnDuration:        1 * time.Hour,
+		ChurnDelay:           5 * time.Minute,
 		Objects: []Object{
 			{Namespaced: true},
 		},

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -138,4 +138,12 @@ type Job struct {
 	PreLoadPeriod time.Duration `yaml:"preLoadPeriod" json:"preLoadPeriod"`
 	// NamespaceLabels add custom labels to namespaces created by kube-burner
 	NamespaceLabels map[string]string `yaml:"namespaceLabels" json:"namespaceLabels,omitempty"`
+	// Churn workload
+	Churn bool `yaml:"churn" json:"churn"`
+	// Churn percentage
+	ChurnPercent int `yaml:"churnPercent" json:"churnPercent"`
+	// Churn duration
+	ChurnDuration time.Duration `yaml:"churnDuration" json:"churnDuration"`
+	// Churn delay between sets
+	ChurnDelay time.Duration `yaml:"churnDelay" json:"churnDelay"`
 }

--- a/test/kube-burner.yml
+++ b/test/kube-burner.yml
@@ -27,6 +27,10 @@ jobs:
     errorOnVerify: true
     jobIterationDelay: 10s
     maxWaitTimeout: 2m
+    churn: true
+    churnPercent: 20
+    churnDuration: 2m
+    churnDelay: 5s
     namespaceLabels:
       foo: bar
       complex.label/test: true

--- a/test/run.sh
+++ b/test/run.sh
@@ -49,7 +49,7 @@ check_files () {
 }
 
 log "Running kube-burner init"
-timeout 300 kube-burner init -c kube-burner.yml --uuid ${uuid} --log-level=debug -u http://localhost:9090 -m metrics-profile.yaml -a alert-profile.yaml
+timeout 500 kube-burner init -c kube-burner.yml --uuid ${uuid} --log-level=debug -u http://localhost:9090 -m metrics-profile.yaml -a alert-profile.yaml
 check_files
 check_ns kube-burner-job=namespaced,kube-burner-uuid=${uuid} 10
 check_destroyed_ns kube-burner-job=not-namespaced,kube-burner-uuid=${uuid}


### PR DESCRIPTION
### Description

Adding the ability to "churn" (delete and recreate) a job in kube-burner.  Churn or the deletion and re-creation of objects, is supported for namespace based jobs only. This occurs after the job has completed but prior to uploading metrics, if applicable. It deletes a percentage of contiguous namespaces randomly chosen and re-creates them with all of the appropriate objects. It will then wait for a specified delay (or none if set to 0 however in testing this may have caused some back off  delays; setting a churn delay of a few seconds remedied that) before deleting and recreating the next randomly chosen set. This cycle continues until the churn duration has passed.

Example input and output:

Snip of input file:
```
jobs:
  - name: cluster-density
    jobIterations: 10
    qps: 20
    burst: 20
    namespacedIterations: true
    namespace: cluster-density
    podWait: false
    cleanup: true
    waitFor: []
    waitWhenFinished: false
    verifyObjects: true
    errorOnVerify: true
    maxWaitTimeout: 1h
    preLoadImages: false
    preLoadPeriod: 2m
    churn: true
    churnPercent: 50
    churnDuration: 2m
    churnDelay: 5s
    namespaceLabels:
      security.openshift.io/scc.podSecurityLabelSync: false
      pod-security.kubernetes.io/enforce: privileged
      pod-security.kubernetes.io/audit: privileged
      pod-security.kubernetes.io/warn: privileged
    objects:

      - objectTemplate: templates/imagestream.yml
        replicas: 3
        inputVars:
          prefix: cluster-density-src
          image: quay.io/cloud-bulldozer/ubi8-go-toolset

      - objectTemplate: templates/imagestream.yml
        replicas: 3
        inputVars:
          prefix: cluster-density-dst
          image: quay.io/cloud-bulldozer/ubi8-go-toolset

      - objectTemplate: templates/buildconfig.yml
        replicas: 3
        inputVars:
          from: cluster-density-src
          to: cluster-density-dst
          gitUri: https://github.com/cloud-bulldozer/hello-openshift.git

      - objectTemplate: templates/imagestream.yml
        replicas: 6
        inputVars:
          prefix: cluster-density

      - objectTemplate: templates/build.yml
        replicas: 6
        inputVars:
          prefix: cluster-density

      - objectTemplate: templates/deployment.yml
        replicas: 1
        inputVars:
          podReplicas: 2
          name: deployment-2pod
          envVar: 55d8...

      - objectTemplate: templates/service.yml
        replicas: 1
        inputVars:
          name: deployment-2pod

      - objectTemplate: templates/deployment.yml
        replicas: 2
        inputVars:
          podReplicas: 1
          name: deployment-1pod
          envVar: 27a6...
      - objectTemplate: templates/service.yml
        replicas: 2
        inputVars:
          name: deployment-1pod

      - objectTemplate: templates/route.yml
        replicas: 1
        inputVars:
          name: deployment-2pod

      - objectTemplate: templates/route.yml
        replicas: 2
        inputVars:
          name: deployment-1pod

      - objectTemplate: templates/secret.yml
        replicas: 10

      - objectTemplate: templates/configmap.yml
        replicas: 10

```

Example output:
```
INFO[2022-09-28 19:43:40] 🔥 Starting kube-burner (churn@eaa2f053f4ceb6b7d6d89c12abe441388cd650bf) with UUID e040f69a-b2be-4079-966a-0a56f533d55f 
INFO[2022-09-28 19:43:40] 📈 Creating measurement factory               
INFO[2022-09-28 19:43:40] Registered measurement: podLatency           
INFO[2022-09-28 19:43:40] Preparing create job: cluster-density        
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 3 ImageStream replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 3 ImageStream replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 3 BuildConfig replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 6 ImageStream replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 6 Build replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 1 Deployment replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 1 Service replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 2 Deployment replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 2 Service replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 1 Route replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 2 Route replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 10 Secret replicas 
INFO[2022-09-28 19:43:40] Job cluster-density: 10 iterations with 10 ConfigMap replicas 
INFO[2022-09-28 19:43:40] Triggering job: cluster-density              
INFO[2022-09-28 19:43:40] Deleting namespaces with label kube-burner-job=cluster-density 
INFO[2022-09-28 19:43:41] Waiting for namespaces to be definitely deleted 
INFO[2022-09-28 19:43:57] Creating Pod latency watcher for cluster-density 
INFO[2022-09-28 19:43:57] QPS: 20                                      
INFO[2022-09-28 19:43:57] Burst: 20                                    
INFO[2022-09-28 19:43:57] Running job cluster-density                  
INFO[2022-09-28 19:44:21] Finished the create job in 24 seconds        
INFO[2022-09-28 19:44:21] Verifying created objects                    
INFO[2022-09-28 19:44:21] imagestreams found: 30 Expected: 30          
INFO[2022-09-28 19:44:21] imagestreams found: 30 Expected: 30          
INFO[2022-09-28 19:44:21] buildconfigs found: 30 Expected: 30          
INFO[2022-09-28 19:44:21] imagestreams found: 60 Expected: 60          
INFO[2022-09-28 19:44:21] builds found: 60 Expected: 60                
INFO[2022-09-28 19:44:21] deployments found: 10 Expected: 10           
INFO[2022-09-28 19:44:21] services found: 10 Expected: 10              
INFO[2022-09-28 19:44:21] deployments found: 20 Expected: 20           
INFO[2022-09-28 19:44:21] services found: 20 Expected: 20              
INFO[2022-09-28 19:44:21] routes found: 10 Expected: 10                
INFO[2022-09-28 19:44:21] routes found: 20 Expected: 20                
INFO[2022-09-28 19:44:22] secrets found: 100 Expected: 100             
INFO[2022-09-28 19:44:22] configmaps found: 100 Expected: 100          
INFO[2022-09-28 19:44:22] Starting to Churn workload                               <-- Churn starts here
INFO[2022-09-28 19:44:22] Churn Duration: 2m0s                         
INFO[2022-09-28 19:44:22] Churn Percent: 50                            
INFO[2022-09-28 19:44:22] Churn Delay: 5s                              
INFO[2022-09-28 19:44:22] Deleting namespaces with label CHURNDELETE=DELETE 
INFO[2022-09-28 19:44:22] Waiting for namespaces to be definitely deleted 
INFO[2022-09-28 19:44:42] Re-creating deleted objects                  
INFO[2022-09-28 19:44:42] QPS: 20                                      
INFO[2022-09-28 19:44:42] Burst: 20                                    
INFO[2022-09-28 19:44:42] Running job cluster-density                  
INFO[2022-09-28 19:44:54] Finished the create job in 11 seconds        
INFO[2022-09-28 19:44:59] Deleting namespaces with label CHURNDELETE=DELETE 
INFO[2022-09-28 19:44:59] Waiting for namespaces to be definitely deleted 
INFO[2022-09-28 19:45:24] Re-creating deleted objects                  
INFO[2022-09-28 19:45:24] QPS: 20                                      
INFO[2022-09-28 19:45:24] Burst: 20                                    
INFO[2022-09-28 19:45:24] Running job cluster-density                  
INFO[2022-09-28 19:45:36] Finished the create job in 11 seconds        
INFO[2022-09-28 19:45:41] Deleting namespaces with label CHURNDELETE=DELETE 
INFO[2022-09-28 19:45:41] Waiting for namespaces to be definitely deleted 
INFO[2022-09-28 19:46:01] Re-creating deleted objects                  
INFO[2022-09-28 19:46:01] QPS: 20                                      
INFO[2022-09-28 19:46:01] Burst: 20                                    
INFO[2022-09-28 19:46:01] Running job cluster-density                  
INFO[2022-09-28 19:46:12] Finished the create job in 12 seconds        
INFO[2022-09-28 19:46:18] Deleting namespaces with label CHURNDELETE=DELETE 
INFO[2022-09-28 19:46:18] Waiting for namespaces to be definitely deleted 
INFO[2022-09-28 19:46:39] Re-creating deleted objects                  
INFO[2022-09-28 19:46:39] QPS: 20                                      
INFO[2022-09-28 19:46:39] Burst: 20                                    
INFO[2022-09-28 19:46:39] Running job cluster-density                  
INFO[2022-09-28 19:46:50] Finished the create job in 12 seconds        
INFO[2022-09-28 19:46:55] Churn workload complete                      
INFO[2022-09-28 19:46:55] Stopping measurement: podLatency             
INFO[2022-09-28 19:46:55] Writing latency metrics in collected-metrics/cluster-density-podLatency.json 
INFO[2022-09-28 19:46:55] Writing latency metrics in collected-metrics/cluster-density-podLatency-summary.json 
INFO[2022-09-28 19:46:55] cluster-density: PodScheduled 50th: 7 99th: 22 max: 28 avg: 8 
INFO[2022-09-28 19:46:55] cluster-density: ContainersReady 50th: 9053 99th: 24332 max: 26513 avg: 10337 
INFO[2022-09-28 19:46:55] cluster-density: Initialized 50th: 5385 99th: 20691 max: 22624 avg: 5995 
INFO[2022-09-28 19:46:55] cluster-density: Ready 50th: 9053 99th: 24332 max: 26513 avg: 10337 
INFO[2022-09-28 19:46:55] Job cluster-density took 195.10 seconds      
INFO[2022-09-28 19:46:55] Finished execution with UUID: e040f69a-b2be-4079-966a-0a56f533d55f 
INFO[2022-09-28 19:46:55] 👋 Exiting kube-burner
```

### Fixes
