### PR TITLE
included a var for pause before scraping metrics

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -48,10 +48,11 @@ func (bat authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // NewPrometheusClient creates a prometheus struct instance with the given parameters
-func NewPrometheusClient(url, token, username, password, uuid string, tlsVerify bool, step time.Duration) (*Prometheus, error) {
+func NewPrometheusClient(url, token, username, password, uuid string, tlsVerify bool, pause time.Duration, step time.Duration) (*Prometheus, error) {
 	var p Prometheus = Prometheus{
-		Step: step,
-		uuid: uuid,
+		Pause: pause,
+		Step:  step,
+		uuid:  uuid,
 	}
 
 	log.Info("👽 Initializing prometheus client")

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -25,6 +25,7 @@ import (
 type Prometheus struct {
 	api           apiv1.API
 	MetricProfile metricProfile
+	Pause         time.Duration
 	Step          time.Duration
 	uuid          string
 }


### PR DESCRIPTION
### Description
Adding a new optional argument `--pause` to have a configurable pause before scrapping metrics from prometheus. This helps in hypershift testing when running kube-burner across 100s of hostedcluster at the same time and let it scrape with a delay to keep the prometheus/thanos from responding too many API queries at a time. 

### Fixes
