### PR TITLE
Use a discoveryAgent go prevent creating clients on init()

### DIFF
--- a/cmd/kube-burner/ocp.go
+++ b/cmd/kube-burner/ocp.go
@@ -22,6 +22,7 @@ import (
 
 	_ "embed"
 
+	"github.com/cloud-bulldozer/kube-burner/pkg/discovery"
 	"github.com/cloud-bulldozer/kube-burner/pkg/workloads"
 	uid "github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
@@ -54,7 +55,8 @@ func openShiftCmd() *cobra.Command {
 			"BURST":     fmt.Sprintf("%d", *burst),
 			"INDEXING":  fmt.Sprintf("%v", indexing),
 		}
-		wh = workloads.NewWorkloadHelper(envVars, *alerting, OCPConfig)
+		discoveryAgent := discovery.NewDiscoveryAgent()
+		wh = workloads.NewWorkloadHelper(envVars, *alerting, OCPConfig, discoveryAgent)
 		wh.Metadata.UUID = *uuid
 		if *esServer != "" {
 			err := wh.GatherMetadata()

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -47,6 +47,7 @@ type WorkloadHelper struct {
 	Metadata        clusterMetadata
 	alerting        bool
 	ocpConfig       embed.FS
+	discoveryAgent  discovery.Agent
 }
 
 type clusterMetadata struct {
@@ -70,17 +71,18 @@ type clusterMetadata struct {
 }
 
 // NewWorkloadHelper initializes workloadHelper
-func NewWorkloadHelper(envVars map[string]string, alerting bool, ocpConfig embed.FS) WorkloadHelper {
+func NewWorkloadHelper(envVars map[string]string, alerting bool, ocpConfig embed.FS, da discovery.Agent) WorkloadHelper {
 	return WorkloadHelper{
-		envVars:   envVars,
-		alerting:  alerting,
-		ocpConfig: ocpConfig,
+		envVars:        envVars,
+		alerting:       alerting,
+		ocpConfig:      ocpConfig,
+		discoveryAgent: da,
 	}
 }
 
 // SetKubeBurnerFlags configures the required environment variables and flags for kube-burner
 func (wh *WorkloadHelper) SetKubeBurnerFlags() {
-	prometheusURL, prometheusToken, err := discovery.GetPrometheus()
+	prometheusURL, prometheusToken, err := wh.discoveryAgent.GetPrometheus()
 	if err != nil {
 		log.Fatal("Error obtaining Prometheus information:", err.Error())
 	}
@@ -92,19 +94,19 @@ func (wh *WorkloadHelper) SetKubeBurnerFlags() {
 }
 
 func (wh *WorkloadHelper) GatherMetadata() error {
-	infra, err := discovery.GetInfraDetails()
+	infra, err := wh.discoveryAgent.GetInfraDetails()
 	if err != nil {
 		return err
 	}
-	version, err := discovery.GetVersionInfo()
+	version, err := wh.discoveryAgent.GetVersionInfo()
 	if err != nil {
 		return err
 	}
-	nodeInfo, err := discovery.GetNodesInfo()
+	nodeInfo, err := wh.discoveryAgent.GetNodesInfo()
 	if err != nil {
 		return err
 	}
-	sdnType, err := discovery.GetSDNInfo()
+	sdnType, err := wh.discoveryAgent.GetSDNInfo()
 	if err != nil {
 		return err
 	}

--- a/pkg/workloads/node-density-cni.go
+++ b/pkg/workloads/node-density-cni.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/cloud-bulldozer/kube-burner/log"
 
-	"github.com/cloud-bulldozer/kube-burner/pkg/discovery"
 	"github.com/spf13/cobra"
 )
 
@@ -40,12 +39,12 @@ func NewNodeDensityCNI(wh *WorkloadHelper) *cobra.Command {
 				os.Exit(0)
 			}
 			wh.Metadata.Benchmark = cmd.Name()
-			workerNodeCount, err := discovery.GetWorkerNodeCount()
+			workerNodeCount, err := wh.discoveryAgent.GetWorkerNodeCount()
 			if err != nil {
 				log.Fatal("Error obtaining worker node count:", err)
 			}
 			totalPods := workerNodeCount * podsPerNode
-			podCount, err := discovery.GetCurrentPodCount()
+			podCount, err := wh.discoveryAgent.GetCurrentPodCount()
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/workloads/node-density-heavy.go
+++ b/pkg/workloads/node-density-heavy.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cloud-bulldozer/kube-burner/log"
 
-	"github.com/cloud-bulldozer/kube-burner/pkg/discovery"
 	"github.com/spf13/cobra"
 )
 
@@ -42,12 +41,12 @@ func NewNodeDensityHeavy(wh *WorkloadHelper) *cobra.Command {
 				os.Exit(0)
 			}
 			wh.Metadata.Benchmark = cmd.Name()
-			workerNodeCount, err := discovery.GetWorkerNodeCount()
+			workerNodeCount, err := wh.discoveryAgent.GetWorkerNodeCount()
 			if err != nil {
 				log.Fatal("Error obtaining worker node count:", err)
 			}
 			totalPods := workerNodeCount * podsPerNode
-			podCount, err := discovery.GetCurrentPodCount()
+			podCount, err := wh.discoveryAgent.GetCurrentPodCount()
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/workloads/node-density.go
+++ b/pkg/workloads/node-density.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cloud-bulldozer/kube-burner/log"
 
-	"github.com/cloud-bulldozer/kube-burner/pkg/discovery"
 	"github.com/spf13/cobra"
 )
 
@@ -43,17 +42,16 @@ func NewNodeDensity(wh *WorkloadHelper) *cobra.Command {
 				os.Exit(0)
 			}
 			wh.Metadata.Benchmark = cmd.Name()
-			workerNodeCount, err := discovery.GetWorkerNodeCount()
+			workerNodeCount, err := wh.discoveryAgent.GetWorkerNodeCount()
 			if err != nil {
 				log.Fatal("Error obtaining worker node count:", err)
 			}
 			totalPods := workerNodeCount * podsPerNode
-			podCount, err := discovery.GetCurrentPodCount()
+			podCount, err := wh.discoveryAgent.GetCurrentPodCount()
 			if err != nil {
 				log.Fatal(err)
 			}
-			jobIterations := totalPods - podCount
-			os.Setenv("JOB_ITERATIONS", fmt.Sprint(jobIterations))
+			os.Setenv("JOB_ITERATIONS", fmt.Sprint(totalPods-podCount))
 			os.Setenv("POD_READY_THRESHOLD", fmt.Sprintf("%v", podReadyThreshold))
 			os.Setenv("CONTAINER_IMAGE", containerImage)
 		},


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

ClientSet is initialized even when running  `kube-burner version`. That's not desired, that command should be available offline

