### PR TITLE
Fix QPS in non-optimal scenarios

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -108,7 +108,7 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int) {
 			log.Fatal(err.Error())
 		}
 	}
-	t0 := time.Now().Round(time.Second)
+	start := time.Now().Round(time.Second)
 	for i := iterationStart; i <= iterationEnd; i++ {
 		log.Debugf("Creating object replicas from iteration %d", i)
 		if ex.nsObjects && ex.Config.NamespacedIterations {
@@ -120,11 +120,8 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int) {
 			}
 		}
 		for objectIndex, obj := range ex.objects {
-			wg.Add(1)
-			go ex.replicaHandler(objectIndex, obj, ns, i, &wg)
+			ex.replicaHandler(objectIndex, obj, ns, i, &wg)
 		}
-		// Wait for all replicaHandlers to finish before moving forward to next iteration
-		wg.Wait()
 		if ex.Config.PodWait {
 			log.Infof("Waiting up to %s all job actions to be completed", ex.Config.MaxWaitTimeout)
 			log.Debugf("Waiting for actions in namespace %v to be completed", ns)
@@ -135,8 +132,9 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int) {
 			time.Sleep(ex.Config.JobIterationDelay)
 		}
 	}
+	// Wait for all replicas to be created
+	wg.Wait()
 	if ex.Config.WaitWhenFinished && !ex.Config.PodWait {
-		wg.Wait()
 		log.Infof("Waiting up to %s for actions to be completed", ex.Config.MaxWaitTimeout)
 		// This semaphore is used to limit the maximum number of concurrent goroutines
 		sem := make(chan int, int(ex.Config.QPS)/2)
@@ -161,15 +159,16 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int) {
 		}
 		wg.Wait()
 	}
-	t1 := time.Now().Round(time.Second)
-	log.Infof("Finished the create job in %g seconds", t1.Sub(t0).Seconds())
+	log.Infof("Finished the create job in %v", time.Since(start).Round(time.Second))
 }
 
-func (ex *Executor) replicaHandler(objectIndex int, obj object, ns string, iteration int, wg *sync.WaitGroup) {
-	defer wg.Done()
+func (ex *Executor) replicaHandler(objectIndex int, obj object, ns string, iteration int, replicaWg *sync.WaitGroup) {
+	var wg sync.WaitGroup
 	for r := 1; r <= obj.replicas; r++ {
 		wg.Add(1)
 		go func(r int) {
+			defer wg.Done()
+			var newObject = new(unstructured.Unstructured)
 			labels := map[string]string{
 				"kube-burner-uuid":  ex.uuid,
 				"kube-burner-job":   ex.Config.Name,
@@ -179,15 +178,12 @@ func (ex *Executor) replicaHandler(objectIndex int, obj object, ns string, itera
 				jobName:      ex.Config.Name,
 				jobIteration: iteration,
 				jobUUID:      ex.uuid,
+				replica:      r,
 			}
 			for k, v := range obj.inputVars {
 				templateData[k] = v
 			}
-			// We are using the same wait group for this inner goroutine, maybe we should consider using a new one
-			defer wg.Done()
 			ex.limiter.Wait(context.TODO())
-			newObject := &unstructured.Unstructured{}
-			templateData[replica] = r
 			renderedObj, err := util.RenderTemplate(obj.objectSpec, templateData, util.MissingKeyError)
 			if err != nil {
 				log.Fatalf("Template error in %s: %s", obj.objectTemplate, err)
@@ -199,9 +195,19 @@ func (ex *Executor) replicaHandler(objectIndex int, obj object, ns string, itera
 			}
 			newObject.SetLabels(labels)
 			json.Marshal(newObject.Object)
-			createRequest(obj.gvr, ns, newObject, obj.namespaced)
+			// replicaWg is necessary because we want to wait for all replicas
+			// to be crated before running any other action such as verify objects,
+			// wait for ready, etc. Without this wait group, running for example,
+			// verify objects can lead into a race condition when some objects
+			// hasn't been created yet
+			replicaWg.Add(1)
+			go func() {
+				createRequest(obj.gvr, ns, newObject, obj.namespaced)
+				replicaWg.Done()
+			}()
 		}(r)
 	}
+	wg.Wait()
 }
 
 func createRequest(gvr schema.GroupVersionResource, ns string, obj *unstructured.Unstructured, namespaced bool) {

--- a/test/run-ocp.sh
+++ b/test/run-ocp.sh
@@ -1,15 +1,16 @@
-#!/bin/bash -ex
+#!/bin/bash
 
 trap 'cleanup' ERR
 
 cleanup() {
-  oc delete ns -l kube-burner-uuid=${UUID} 
+  oc delete ns -l kube-burner-uuid=${UUID} --ignore-not-found
+  exit 1
 }
 
 UUID=$(uuidgen)
 ES_SERVER="https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com/"
 ES_INDEX="kube-burner-ocp"
-COMMON_FLAGS="--es-server=${ES_SERVER} --es-index=${ES_INDEX} --alerting=false --uuid=${UUID}"
+COMMON_FLAGS="--es-server=${ES_SERVER} --es-index=${ES_INDEX} --alerting=false --uuid=${UUID} --qps=5 --burst=5"
 
 echo "Running node-density wrapper"
 kube-burner ocp node-density --pods-per-node=75 --pod-ready-threshold=10s --container-image=gcr.io/google_containers/pause:3.0 ${COMMON_FLAGS}


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

The original implementation uses creates a new go-routine per replica, in scenarios where there's only one object replica per iteration (node-density), kube-burner might not reach the configured QPS ratio . This is more likely in scenarios where there're some delay from the API, like when network latency with the API is not 100% optimal.

This new implementation makes API calls not blocker since they are now encapsulated in their own go-routines.

