### PR TITLE
Churning improvements

### DIFF
--- a/cmd/kube-burner/ocp-config/cluster-density/np-allow-from-clients.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density/np-allow-from-clients.yml
@@ -16,6 +16,4 @@ spec:
           name: client-{{.Replica}}
   - ports:
     - protocol: TCP
-      port: 8443
-    - protocol: TCP
       port: 8080

--- a/cmd/kube-burner/ocp-config/cluster-density/np-allow-from-ingress.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density/np-allow-from-ingress.yml
@@ -10,8 +10,6 @@ spec:
           network.openshift.io/policy-group: ingress
   - ports:
     - protocol: TCP
-      port: 8443
-    - protocol: TCP
       port: 8080
   podSelector: {}
   policyTypes:

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -244,13 +244,10 @@ func createRequest(gvr schema.GroupVersionResource, ns string, obj *unstructured
 // RunCreateJobWithChurn executes a churn creation job
 func (ex *Executor) RunCreateJobWithChurn() {
 	var err error
-	log.Info("Starting to Churn job")
-	log.Infof("Churn duration: %v", ex.Config.ChurnDuration)
-	log.Infof("Churn percent: %v", ex.Config.ChurnPercent)
-	log.Infof("Churn delay: %v", ex.Config.ChurnDelay)
 	// Determine the number of job iterations to churn (min 1)
 	numToChurn := int(math.Max(float64(ex.Config.ChurnPercent*ex.Config.JobIterations/100), 1))
 	now := time.Now().UTC()
+	rand.Seed(now.UnixNano())
 	// Create timer for the churn duration
 	timer := time.After(ex.Config.ChurnDuration)
 	// Patch to label namespaces for deletion

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -261,7 +261,7 @@ func (ex *Executor) RunCreateJobWithChurn() {
 			log.Info("Churn job complete")
 			return
 		default:
-			log.Infof("Next churn loop, workload churning started %v ago", time.Since(now))
+			log.Debugf("Next churn loop, workload churning started %v ago", time.Since(now))
 		}
 		// Max amount of churn is 100% of namespaces
 		randStart := 1

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -117,6 +117,12 @@ func Run(configSpec config.Spec, uuid string, p *prometheus.Prometheus, alertM *
 				job.Cleanup()
 				measurements.Start(&measurementsWg)
 				measurementsWg.Wait()
+				if job.Config.Churn {
+					log.Info("Churning enabled")
+					log.Infof("Churn duration: %v", job.Config.ChurnDuration)
+					log.Infof("Churn percent: %v", job.Config.ChurnPercent)
+					log.Infof("Churn delay: %v", job.Config.ChurnDelay)
+				}
 				job.RunCreateJob(1, job.Config.JobIterations)
 				// If object verification is enabled
 				if job.Config.VerifyObjects && !job.Verify() {

--- a/pkg/workloads/cluster-density.go
+++ b/pkg/workloads/cluster-density.go
@@ -53,7 +53,7 @@ func NewClusterDensity(wh *WorkloadHelper) *cobra.Command {
 	cmd.Flags().IntVar(&iterations, "iterations", 0, "Cluster-density iterations")
 	cmd.Flags().BoolVar(&churn, "churn", true, "Enable churning")
 	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 1*time.Hour, "Churn duration")
-	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 30*time.Second, "Time to wait between each churn")
+	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")
 	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
 	cmd.Flags().BoolVar(&extract, "extract", false, "Extract workload in the current directory")
 	cmd.MarkFlagRequired("iterations")


### PR DESCRIPTION
### Description

Improve churning code and increase churning delay
The default churning delay of 30s is very short, the cluster-density workload on this repo is more complex in terms of networking requirements, and needs a higher value (2 mins) to prevent excessive SDN delays.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>