### PR TITLE
Cluster-density network-policies flag and increase default timeout

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -138,7 +138,7 @@ func initCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&alertProfile, "alert-profile", "a", "", "Alert profile file or URL")
 	cmd.Flags().BoolVar(&skipTLSVerify, "skip-tls-verify", true, "Verify prometheus TLS certificate")
 	cmd.Flags().DurationVarP(&prometheusStep, "step", "s", 30*time.Second, "Prometheus step size")
-	cmd.Flags().DurationVarP(&timeout, "timeout", "", 2*time.Hour, "Benchmark timeout")
+	cmd.Flags().DurationVarP(&timeout, "timeout", "", 4*time.Hour, "Benchmark timeout")
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "Config file path or URL")
 	cmd.Flags().StringVarP(&configMap, "configmap", "", "", "Configmap holding all the configuration: config.yml, metrics.yml and alerts.yml. metrics and alerts are optional")
 	cmd.Flags().StringVarP(&namespace, "namespace", "", "default", "Namespace where the configmap is")

--- a/cmd/kube-burner/ocp-config/cluster-density/cluster-density.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density/cluster-density.yml
@@ -61,7 +61,7 @@ jobs:
 
       - objectTemplate: configmap.yml
         replicas: 10
-
+{{ if eq .NETWORK_POLICIES "true" }}
       - objectTemplate: np-deny-all.yml
         replicas: 1
 
@@ -70,3 +70,4 @@ jobs:
 
       - objectTemplate: np-allow-from-ingress.yml
         replicas: 1
+{{ end }}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,7 @@ This option is meant to run Kube-burner benchmark, and it supports the these fla
 - password: Prometheus password for basic authentication.
 - skip-tls-verify: Skip TLS verification for prometheus. Default `true`
 - step: Prometheus step size. Default `30s`
-- timeout: Kube-burner benchmark global timeout. When timing out, return code is 2. Default `2h`
+- timeout: Kube-burner benchmark global timeout. When timing out, return code is 2. Default `4h`
 
 **Note**: Both basic authentication and Bearer authentication need credentials able to query the given Prometheus API.
 

--- a/pkg/workloads/cluster-density.go
+++ b/pkg/workloads/cluster-density.go
@@ -27,7 +27,7 @@ import (
 // NewClusterDensity holds cluster-density workload
 func NewClusterDensity(wh *WorkloadHelper) *cobra.Command {
 	var iterations, churnPercent int
-	var churn, extract bool
+	var churn, extract, networkPolicies bool
 	var churnDelay, churnDuration time.Duration
 	cmd := &cobra.Command{
 		Use:   "cluster-density",
@@ -45,6 +45,7 @@ func NewClusterDensity(wh *WorkloadHelper) *cobra.Command {
 			os.Setenv("CHURN_DURATION", fmt.Sprintf("%v", churnDuration))
 			os.Setenv("CHURN_DELAY", fmt.Sprintf("%v", churnDelay))
 			os.Setenv("CHURN_PERCENT", fmt.Sprint(churnPercent))
+			os.Setenv("NETWORK_POLICIES", fmt.Sprint(networkPolicies))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			wh.run(cmd.Name())
@@ -55,6 +56,7 @@ func NewClusterDensity(wh *WorkloadHelper) *cobra.Command {
 	cmd.Flags().DurationVar(&churnDuration, "churn-duration", 1*time.Hour, "Churn duration")
 	cmd.Flags().DurationVar(&churnDelay, "churn-delay", 2*time.Minute, "Time to wait between each churn")
 	cmd.Flags().IntVar(&churnPercent, "churn-percent", 10, "Percentage of job iterations that kube-burner will churn each round")
+	cmd.Flags().BoolVar(&networkPolicies, "network-policies", true, "Enable network policies in the workload")
 	cmd.Flags().BoolVar(&extract, "extract", false, "Extract workload in the current directory")
 	cmd.MarkFlagRequired("iterations")
 	return cmd

--- a/test/run-ocp.sh
+++ b/test/run-ocp.sh
@@ -21,6 +21,8 @@ echo "Running node-density-heavy wrapper"
 kube-burner ocp node-density-heavy --pods-per-node=75 ${COMMON_FLAGS} --qps=5 --burst=5
 echo "Running cluster-density wrapper"
 kube-burner ocp cluster-density --iterations=3 --churn-duration=2m ${COMMON_FLAGS}
+echo "Running cluster-density wrapper w/o network-policies"
+kube-burner ocp cluster-density --iterations=2 churning=false --uuid=${UUID} --network-policies=false
 # Disable gc and avoid metric indexing
 echo "Running node-density-cni wrapper"
 kube-burner ocp node-density-cni --pods-per-node=75 --gc=false --uuid=${UUID} --alerting=false


### PR DESCRIPTION
### Description

Add flag to opt-out network policies from the cluster-density workload
Pass the `--network-policies=false` argument to disable them

And increase default timeout to 4h

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>
