### PR TITLE
Index cluster metadata before garbage collecting stuff

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -84,6 +84,7 @@ func initCmd() *cobra.Command {
 	var prometheusClient *prometheus.Prometheus
 	var alertM *alerting.AlertManager
 	var timeout time.Duration
+	garbageCollect := make(chan bool)
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Launch benchmark",
@@ -125,6 +126,9 @@ func initCmd() *cobra.Command {
 			rc, err := burner.Run(configSpec, uuid, prometheusClient, alertM, timeout)
 			if err != nil {
 				log.Fatalf(err.Error())
+			}
+			if configSpec.GlobalConfig.GC {
+				burner.GarbageCollect(uuid)
 			}
 			os.Exit(rc)
 		},

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -194,10 +194,6 @@ func Run(configSpec config.Spec, uuid string, p *prometheus.Prometheus, alertM *
 			}
 		}
 		log.Infof("Finished execution with UUID: %s", uuid)
-		if configSpec.GlobalConfig.GC {
-			log.Info("Garbage collecting created namespaces")
-			CleanupNamespaces(v1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-uuid=%v", uuid)})
-		}
 		res <- innerRC
 	}()
 	select {
@@ -208,6 +204,11 @@ func Run(configSpec config.Spec, uuid string, p *prometheus.Prometheus, alertM *
 	}
 	log.Info("👋 Exiting kube-burner ", uuid)
 	return rc, nil
+}
+
+func GarbageCollect(uuid string) {
+	log.Info("Garbage collecting created namespaces")
+	CleanupNamespaces(v1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-uuid=%v", uuid)})
 }
 
 // newExecutorList Returns a list of executors

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -184,12 +184,16 @@ func (wh *WorkloadHelper) run(workload string) {
 			log.Fatal(err)
 		}
 	}
+	// Wait for workload to finish before running garbage collection
 	rc, err = burner.Run(configSpec, wh.Metadata.UUID, p, alertM, wh.timeout)
 	if err != nil {
 		log.Fatal(err)
 	}
 	wh.Metadata.Passed = rc == 0
 	wh.indexMetadata()
+	if configSpec.GlobalConfig.GC {
+		burner.GarbageCollect(wh.Metadata.UUID)
+	}
 	os.Exit(rc)
 }
 


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

This will prevent timing a test out w/o indexing metadata

### Fixes
