### PR TITLE
ClientSet for wait functions

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -35,11 +35,17 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 )
 
 func setupCreateJob(jobConfig config.Job) Executor {
 	var f io.Reader
 	var err error
+	waitClientSet, waitRestConfig, err = config.GetClientSet(jobConfig.QPS*2, jobConfig.Burst*2)
+	if err != nil {
+		log.Fatalf("Error creating wait clientSet: %s", err.Error())
+	}
+	waitDynamicClient = dynamic.NewForConfigOrDie(waitRestConfig)
 	log.Debugf("Preparing create job: %s", jobConfig.Name)
 	selector := util.NewSelector()
 	selector.Configure("", fmt.Sprintf("kube-burner-job=%s", jobConfig.Name), "")

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -69,8 +69,11 @@ const (
 )
 
 var ClientSet *kubernetes.Clientset
+var waitClientSet *kubernetes.Clientset
 var dynamicClient dynamic.Interface
+var waitDynamicClient dynamic.Interface
 var restConfig *rest.Config
+var waitRestConfig *rest.Config
 
 //nolint:gocyclo
 func Run(configSpec config.Spec, uuid string, p *prometheus.Prometheus, alertM *alerting.AlertManager, indexer *indexers.Indexer, timeout time.Duration) (int, error) {

--- a/pkg/burner/waiters.go
+++ b/pkg/burner/waiters.go
@@ -82,7 +82,7 @@ func waitForDeployments(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGr
 	defer wg.Done()
 	// TODO handle errors such as timeouts
 	wait.PollImmediate(1*time.Second, maxWaitTimeout, func() (bool, error) {
-		deps, err := ClientSet.AppsV1().Deployments(ns).List(context.TODO(), metav1.ListOptions{})
+		deps, err := waitClientSet.AppsV1().Deployments(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -99,7 +99,7 @@ func waitForDeployments(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGr
 func waitForRS(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 	defer wg.Done()
 	wait.PollImmediate(1*time.Second, maxWaitTimeout, func() (bool, error) {
-		rss, err := ClientSet.AppsV1().ReplicaSets(ns).List(context.TODO(), metav1.ListOptions{})
+		rss, err := waitClientSet.AppsV1().ReplicaSets(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -116,7 +116,7 @@ func waitForRS(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 func waitForStatefulSet(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 	defer wg.Done()
 	wait.PollImmediate(1*time.Second, maxWaitTimeout, func() (bool, error) {
-		stss, err := ClientSet.AppsV1().StatefulSets(ns).List(context.TODO(), metav1.ListOptions{})
+		stss, err := waitClientSet.AppsV1().StatefulSets(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -133,7 +133,7 @@ func waitForStatefulSet(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGr
 func waitForPVC(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 	defer wg.Done()
 	wait.PollImmediate(1*time.Second, maxWaitTimeout, func() (bool, error) {
-		pvc, err := ClientSet.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase!=Bound"})
+		pvc, err := waitClientSet.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase!=Bound"})
 		if err != nil {
 			return false, err
 		}
@@ -144,7 +144,7 @@ func waitForPVC(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 func waitForRC(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 	defer wg.Done()
 	wait.PollImmediate(1*time.Second, maxWaitTimeout, func() (bool, error) {
-		rcs, err := ClientSet.CoreV1().ReplicationControllers(ns).List(context.TODO(), metav1.ListOptions{})
+		rcs, err := waitClientSet.CoreV1().ReplicationControllers(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -161,7 +161,7 @@ func waitForRC(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 func waitForDS(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 	defer wg.Done()
 	wait.PollImmediate(1*time.Second, maxWaitTimeout, func() (bool, error) {
-		dss, err := ClientSet.AppsV1().DaemonSets(ns).List(context.TODO(), metav1.ListOptions{})
+		dss, err := waitClientSet.AppsV1().DaemonSets(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -178,7 +178,7 @@ func waitForDS(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 func waitForPod(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 	defer wg.Done()
 	wait.PollImmediate(1*time.Second, maxWaitTimeout, func() (bool, error) {
-		pods, err := ClientSet.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase!=Running"})
+		pods, err := waitClientSet.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase!=Running"})
 		if err != nil {
 			return false, err
 		}
@@ -196,7 +196,7 @@ func waitForBuild(ns string, maxWaitTimeout time.Duration, expected int, wg *syn
 		Resource: types.OpenShiftBuildResource,
 	}
 	wait.PollImmediate(1*time.Second, maxWaitTimeout, func() (bool, error) {
-		builds, err := dynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
+		builds, err := waitDynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -234,7 +234,7 @@ func waitForJob(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 func verifyCondition(gvr schema.GroupVersionResource, ns, condition string, maxWaitTimeout time.Duration) {
 	var uObj types.UnstructuredContent
 	wait.PollImmediate(10*time.Second, maxWaitTimeout, func() (bool, error) {
-		objs, err := dynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
+		objs, err := waitDynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -289,7 +289,7 @@ func waitForVMIRS(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 		Resource: types.VirtualMachineInstanceReplicaSetResource,
 	}
 	wait.PollImmediate(10*time.Second, maxWaitTimeout, func() (bool, error) {
-		objs, err := dynamicClient.Resource(vmiGVRRS).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
+		objs, err := waitDynamicClient.Resource(vmiGVRRS).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			log.Debugf("replicaSets error %v", err)
 			return false, err


### PR DESCRIPTION
### Description

Given that the wait functions use a rate mechanism uses QPSx2 goroutines/s it's possible to observe client-side throttling since #goroutines > QPS like the below

```
I0123 17:27:24.771852 1651939 request.go:682] Waited for 2.996191263s due to client-side throttling, not priority and fairness, request: GET:https://198.18.10.132:6443/apis/apps/v1/namespaces/cluster-density-181/deployments
```

We need to create a new clientSet with higher QPS (actually x2) to be used by the wait functions to prevent it:

