### PR TITLE
Add additional metadata to metrics

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -148,6 +148,7 @@ func Run(configSpec config.Spec, uuid string, p *prometheus.Prometheus, alertM *
 			}
 			jobList[jobPosition].End = time.Now().UTC()
 			prometheusJob.End = jobList[jobPosition].End
+			prometheusJob.JobConfig = job.Config
 			elapsedTime := prometheusJob.End.Sub(prometheusJob.Start).Seconds()
 			// Don't append to Prometheus jobList when prometheus it's not initialized
 			if p != nil {

--- a/pkg/measurements/metrics/metrics.go
+++ b/pkg/measurements/metrics/metrics.go
@@ -23,21 +23,23 @@ import (
 	"time"
 
 	"github.com/cloud-bulldozer/kube-burner/log"
+	"github.com/cloud-bulldozer/kube-burner/pkg/config"
 	"github.com/cloud-bulldozer/kube-burner/pkg/measurements/types"
 )
 
 // LatencyQuantiles holds the latency measurement quantiles
 type LatencyQuantiles struct {
-	QuantileName string    `json:"quantileName"`
-	UUID         string    `json:"uuid"`
-	P99          int       `json:"P99"`
-	P95          int       `json:"P95"`
-	P50          int       `json:"P50"`
-	Max          int       `json:"max"`
-	Avg          int       `json:"avg"`
-	Timestamp    time.Time `json:"timestamp"`
-	MetricName   string    `json:"metricName"`
-	JobName      string    `json:"jobName"`
+	QuantileName string     `json:"quantileName"`
+	UUID         string     `json:"uuid"`
+	P99          int        `json:"P99"`
+	P95          int        `json:"P95"`
+	P50          int        `json:"P50"`
+	Max          int        `json:"max"`
+	Avg          int        `json:"avg"`
+	Timestamp    time.Time  `json:"timestamp"`
+	MetricName   string     `json:"metricName"`
+	JobName      string     `json:"jobName"`
+	JobConfig    config.Job `json:"jobConfig"`
 }
 
 // SetQuantile adds quantile value

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -33,9 +33,10 @@ type Prometheus struct {
 }
 
 type Job struct {
-	Start time.Time
-	End   time.Time
-	Name  string
+	Start     time.Time
+	End       time.Time
+	Name      string
+	JobConfig config.Job
 }
 
 // This object implements RoundTripper
@@ -62,4 +63,5 @@ type metric struct {
 	Query      string            `json:"query"`
 	MetricName string            `json:"metricName,omitempty"`
 	JobName    string            `json:"jobName,omitempty"`
+	JobConfig  config.Job        `json:"jobConfig,omitempty"`
 }


### PR DESCRIPTION
### Description
- Add JobConfig metadata to all metric data

To Do :
- Add Extra metadata to all metric data from ocp wrapper

Note: Ignore JobConfig.Objects

### Fixes
Addresses some of https://github.com/cloud-bulldozer/kube-burner/issues/250