### PR TITLE
Add OCP metadata to each document

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -124,7 +124,7 @@ func initCmd() *cobra.Command {
 				}
 			}
 			if url != "" {
-				prometheusClient, err = prometheus.NewPrometheusClient(configSpec, url, token, username, password, uuid, skipTLSVerify, prometheusStep)
+				prometheusClient, err = prometheus.NewPrometheusClient(configSpec, url, token, username, password, uuid, skipTLSVerify, prometheusStep, map[string]interface{}{})
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -134,7 +134,7 @@ func initCmd() *cobra.Command {
 					}
 				}
 			}
-			rc, err = burner.Run(configSpec, uuid, prometheusClient, alertM, indexer, timeout)
+			rc, err = burner.Run(configSpec, uuid, prometheusClient, alertM, indexer, timeout, map[string]interface{}{})
 			if err != nil {
 				log.Fatalf(err.Error())
 			}
@@ -223,7 +223,7 @@ func indexCmd() *cobra.Command {
 			if metricsProfile != "" {
 				configSpec.GlobalConfig.MetricsProfile = metricsProfile
 			}
-			p, err := prometheus.NewPrometheusClient(configSpec, url, token, username, password, uuid, skipTLSVerify, prometheusStep)
+			p, err := prometheus.NewPrometheusClient(configSpec, url, token, username, password, uuid, skipTLSVerify, prometheusStep, map[string]interface{}{})
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -261,6 +261,7 @@ func indexCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&jobName, "job-name", "j", "kube-burner-indexing", "Indexing job name")
 	cmd.MarkFlagRequired("prometheus-url")
 	cmd.MarkFlagRequired("config")
+	cmd.MarkFlagsMutuallyExclusive("prometheus-url", "config")
 	cmd.Flags().SortFlags = false
 	return cmd
 }
@@ -326,7 +327,7 @@ func alertCmd() *cobra.Command {
 			if token == "" {
 				token = configSpec.GlobalConfig.BearerToken
 			}
-			p, err := prometheus.NewPrometheusClient(configSpec, url, token, username, password, uuid, skipTLSVerify, prometheusStep)
+			p, err := prometheus.NewPrometheusClient(configSpec, url, token, username, password, uuid, skipTLSVerify, prometheusStep, map[string]interface{}{})
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -368,7 +369,7 @@ func main() {
 		importCmd(),
 		openShiftCmd(),
 	)
-	logLevel := rootCmd.PersistentFlags().String("log-level", "info", "Allowed values: trace, debug, info, warn, error, fatal")
+	logLevel := rootCmd.PersistentFlags().String("log-level", "info", "Allowed values: debug, info, warn, error, fatal")
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		log.SetLogLevel(*logLevel)
 	}

--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cloud-bulldozer/kube-burner/pkg/alerting"
 	"github.com/cloud-bulldozer/kube-burner/pkg/burner"
 	"github.com/cloud-bulldozer/kube-burner/pkg/config"
+	"github.com/cloud-bulldozer/kube-burner/pkg/util"
 	"github.com/cloud-bulldozer/kube-burner/pkg/version"
 
 	"github.com/cloud-bulldozer/kube-burner/pkg/indexers"
@@ -79,7 +80,7 @@ To configure your bash shell to load completions for each session execute:
 func initCmd() *cobra.Command {
 	var err error
 	var url, metricsProfile, alertProfile, configFile string
-	var username, password, uuid, token, configMap, namespace string
+	var username, password, uuid, token, configMap, namespace, userMetadata string
 	var skipTLSVerify bool
 	var prometheusStep time.Duration
 	var prometheusClient *prometheus.Prometheus
@@ -96,6 +97,7 @@ func initCmd() *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			userMetadataContent := make(map[string]interface{})
 			if configMap != "" {
 				metricsProfile, alertProfile, err = config.FetchConfigMap(configMap, namespace)
 				if err != nil {
@@ -134,7 +136,13 @@ func initCmd() *cobra.Command {
 					}
 				}
 			}
-			rc, err = burner.Run(configSpec, uuid, prometheusClient, alertM, indexer, timeout, map[string]interface{}{})
+			if userMetadata != "" {
+				userMetadataContent, err = util.ReadUserMetadata(userMetadata)
+				if err != nil {
+					log.Fatalf("Error reading provided user metadata: %v", err)
+				}
+			}
+			rc, err = burner.Run(configSpec, uuid, prometheusClient, alertM, indexer, timeout, userMetadataContent)
 			if err != nil {
 				log.Fatalf(err.Error())
 			}
@@ -154,6 +162,7 @@ func initCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&configMap, "configmap", "", "", "Configmap holding all the configuration: config.yml, metrics.yml and alerts.yml. metrics and alerts are optional")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace where the configmap is")
 	cmd.MarkFlagsMutuallyExclusive("config", "configmap")
+	cmd.Flags().StringVar(&userMetadata, "user-metadata", "", "User provided metadata file, in YAML format")
 	cmd.Flags().SortFlags = false
 	return cmd
 }
@@ -192,7 +201,7 @@ func destroyCmd() *cobra.Command {
 func indexCmd() *cobra.Command {
 	var url, metricsProfile, configFile, jobName string
 	var start, end int64
-	var username, password, uuid, token string
+	var username, password, uuid, token, userMetadata string
 	var skipTLSVerify bool
 	var prometheusStep time.Duration
 	var indexer *indexers.Indexer
@@ -204,6 +213,7 @@ func indexCmd() *cobra.Command {
 			log.Info("👋 Exiting kube-burner ", uuid)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			userMetadataContent := make(map[string]interface{})
 			configSpec, err := config.Parse(configFile, false)
 			if err != nil {
 				log.Fatal(err.Error())
@@ -223,7 +233,13 @@ func indexCmd() *cobra.Command {
 			if metricsProfile != "" {
 				configSpec.GlobalConfig.MetricsProfile = metricsProfile
 			}
-			p, err := prometheus.NewPrometheusClient(configSpec, url, token, username, password, uuid, skipTLSVerify, prometheusStep, map[string]interface{}{})
+			if userMetadata != "" {
+				userMetadataContent, err = util.ReadUserMetadata(userMetadata)
+				if err != nil {
+					log.Fatalf("Error reading provided user metadata: %v", err)
+				}
+			}
+			p, err := prometheus.NewPrometheusClient(configSpec, url, token, username, password, uuid, skipTLSVerify, prometheusStep, userMetadataContent)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -259,6 +275,7 @@ func indexCmd() *cobra.Command {
 	cmd.Flags().Int64VarP(&end, "end", "", time.Now().Unix(), "Epoch end time")
 	cmd.Flags().StringVarP(&configFile, "config", "c", "", "Config file path or URL")
 	cmd.Flags().StringVarP(&jobName, "job-name", "j", "kube-burner-indexing", "Indexing job name")
+	cmd.Flags().StringVar(&userMetadata, "user-metadata", "", "User provided metadata file, in YAML format")
 	cmd.MarkFlagRequired("prometheus-url")
 	cmd.MarkFlagRequired("config")
 	cmd.MarkFlagsMutuallyExclusive("prometheus-url", "config")

--- a/cmd/kube-burner/ocp.go
+++ b/cmd/kube-burner/ocp.go
@@ -46,6 +46,7 @@ func openShiftCmd() *cobra.Command {
 	qps := ocpCmd.PersistentFlags().Int("qps", 20, "QPS")
 	burst := ocpCmd.PersistentFlags().Int("burst", 20, "Burst")
 	gc := ocpCmd.PersistentFlags().Bool("gc", true, "Garbage collect created namespaces")
+	userMetadata := ocpCmd.PersistentFlags().String("user-metadata", "", "User provided metadata file, in YAML format")
 	ocpCmd.MarkFlagsRequiredTogether("es-server", "es-index")
 	ocpCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		rootCmd.PersistentPreRun(cmd, args)
@@ -59,7 +60,7 @@ func openShiftCmd() *cobra.Command {
 			"GC":        fmt.Sprintf("%v", *gc),
 		}
 		discoveryAgent := discovery.NewDiscoveryAgent()
-		wh = workloads.NewWorkloadHelper(envVars, *alerting, OCPConfig, discoveryAgent, indexing, *timeout)
+		wh = workloads.NewWorkloadHelper(envVars, *alerting, OCPConfig, discoveryAgent, indexing, *timeout, *userMetadata)
 		wh.Metadata.UUID = *uuid
 		if *esServer != "" {
 			err := wh.GatherMetadata()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,6 +45,7 @@ This option is meant to run Kube-burner benchmark, and it supports the these fla
 - skip-tls-verify: Skip TLS verification for prometheus. Default `true`
 - step: Prometheus step size. Default `30s`
 - timeout: Kube-burner benchmark global timeout. When timing out, return code is 2. Default `4h`
+- user-metadata: YAML file path containing custom user-metadata to be indexed.
 
 **Note**: Both basic authentication and Bearer authentication need credentials able to query the given Prometheus API.
 

--- a/log/log.go
+++ b/log/log.go
@@ -61,8 +61,6 @@ func init() {
 // SetLogLevel sets log level
 func SetLogLevel(logLevel string) {
 	switch logLevel {
-	case "trace":
-		defaultLogger.Level = logrus.TraceLevel
 	case "debug":
 		defaultLogger.Level = logrus.DebugLevel
 	case "warn":

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -77,7 +77,7 @@ var restConfig *rest.Config
 var waitRestConfig *rest.Config
 
 //nolint:gocyclo
-func Run(configSpec config.Spec, uuid string, p *prometheus.Prometheus, alertM *alerting.AlertManager, indexer *indexers.Indexer, timeout time.Duration) (int, error) {
+func Run(configSpec config.Spec, uuid string, p *prometheus.Prometheus, alertM *alerting.AlertManager, indexer *indexers.Indexer, timeout time.Duration, metadata map[string]interface{}) (int, error) {
 	var err error
 	var rc int
 	var measurementsWg sync.WaitGroup
@@ -85,7 +85,7 @@ func Run(configSpec config.Spec, uuid string, p *prometheus.Prometheus, alertM *
 	log.Infof("🔥 Starting kube-burner (%s@%s) with UUID %s", version.Version, version.GitCommit, uuid)
 	go func() {
 		var innerRC int
-		measurements.NewMeasurementFactory(configSpec, uuid, indexer)
+		measurements.NewMeasurementFactory(configSpec, uuid, indexer, metadata)
 		jobList := newExecutorList(configSpec, uuid)
 		// Iterate job list
 		for jobPosition, job := range jobList {

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -164,7 +164,7 @@ func Run(configSpec config.Spec, uuid string, p *prometheus.Prometheus, alertM *
 		if configSpec.GlobalConfig.IndexerConfig.Enabled {
 			for _, job := range jobList {
 				elapsedTime := job.End.Sub(job.Start).Seconds()
-				err := indexMetadataInfo(configSpec, indexer, uuid, elapsedTime, job.Config, job.Start)
+				err := indexjobSummaryInfo(configSpec, indexer, uuid, elapsedTime, job.Config, job.Start, metadata)
 				if err != nil {
 					log.Errorf(err.Error())
 				}

--- a/pkg/burner/metadata.go
+++ b/pkg/burner/metadata.go
@@ -26,25 +26,27 @@ import (
 	"github.com/cloud-bulldozer/kube-burner/pkg/indexers"
 )
 
-type metadata struct {
-	Timestamp   time.Time  `json:"timestamp"`
-	UUID        string     `json:"uuid"`
-	MetricName  string     `json:"metricName"`
-	ElapsedTime float64    `json:"elapsedTime"`
-	JobConfig   config.Job `json:"jobConfig"`
+type jobSummary struct {
+	Timestamp   time.Time              `json:"timestamp"`
+	UUID        string                 `json:"uuid"`
+	MetricName  string                 `json:"metricName"`
+	ElapsedTime float64                `json:"elapsedTime"`
+	JobConfig   config.Job             `json:"jobConfig"`
+	Metadata    map[string]interface{} `json:"metadata"`
 }
 
-const jobSummary = "jobSummary"
+const jobSummaryMetric = "jobSummary"
 
 // indexMetadataInfo Generates and indexes a document with metadata information of the passed job
-func indexMetadataInfo(configSpec config.Spec, indexer *indexers.Indexer, uuid string, elapsedTime float64, jobConfig config.Job, timestamp time.Time) error {
+func indexjobSummaryInfo(configSpec config.Spec, indexer *indexers.Indexer, uuid string, elapsedTime float64, jobConfig config.Job, timestamp time.Time, metadata map[string]interface{}) error {
 	metadataInfo := []interface{}{
-		metadata{
+		jobSummary{
 			UUID:        uuid,
 			ElapsedTime: elapsedTime,
 			JobConfig:   jobConfig,
-			MetricName:  jobSummary,
+			MetricName:  jobSummaryMetric,
 			Timestamp:   timestamp,
+			Metadata:    metadata,
 		},
 	}
 	if configSpec.GlobalConfig.WriteToFile {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -105,53 +105,53 @@ type Object struct {
 // Job defines a kube-burner job
 type Job struct {
 	// IterationCount how many times to execute the job
-	JobIterations int `yaml:"jobIterations" json:"jobIterations"`
+	JobIterations int `yaml:"jobIterations" json:"jobIterations,omitempty"`
 	// IterationDelay how much time to wait between each job iteration
-	JobIterationDelay time.Duration `yaml:"jobIterationDelay" json:"jobIterationDelay"`
+	JobIterationDelay time.Duration `yaml:"jobIterationDelay" json:"jobIterationDelay,omitempty"`
 	// JobPause how much time to pause after finishing the job
-	JobPause time.Duration `yaml:"jobPause" json:"jobPause"`
+	JobPause time.Duration `yaml:"jobPause" json:"jobPause,omitempty"`
 	// Name job name
-	Name string `yaml:"name" json:"name"`
+	Name string `yaml:"name" json:"name,omitempty"`
 	// Objects list of objects
-	Objects []Object `yaml:"objects" json:"objects"`
+	Objects []Object `yaml:"objects" json:"objects,omitempty"`
 	// JobType type of job
-	JobType JobType `yaml:"jobType" json:"jobType"`
+	JobType JobType `yaml:"jobType" json:"jobType,omitempty"`
 	// Max number of queries per second
-	QPS float32 `yaml:"qps" json:"qps"`
+	QPS float32 `yaml:"qps" json:"qps,omitempty"`
 	// Maximum burst for throttle
-	Burst int `yaml:"burst" json:"burst"`
+	Burst int `yaml:"burst" json:"burst,omitempty"`
 	// Namespace namespace base name to use
-	Namespace string `yaml:"namespace" json:"namespace"`
+	Namespace string `yaml:"namespace" json:"namespace,omitempty"`
 	// WaitFor list of objects to wait for, if not specified wait for all
-	WaitFor []string `yaml:"waitFor" json:"waitFor"`
+	WaitFor []string `yaml:"waitFor" json:"waitFor,omitempty"`
 	// MaxWaitTimeout maximum wait period
-	MaxWaitTimeout time.Duration `yaml:"maxWaitTimeout" json:"maxWaitTimeout"`
+	MaxWaitTimeout time.Duration `yaml:"maxWaitTimeout" json:"maxWaitTimeout,omitempty"`
 	// WaitForDeletion wait for objects to be definitively deleted
-	WaitForDeletion bool `yaml:"waitForDeletion" json:"waitForDeletion"`
+	WaitForDeletion bool `yaml:"waitForDeletion" json:"waitForDeletion,omitempty"`
 	// PodWait wait for all pods to be running before moving forward to the next iteration
-	PodWait bool `yaml:"podWait" json:"podWait"`
+	PodWait bool `yaml:"podWait" json:"podWait,omitempty"`
 	// WaitWhenFinished Wait for pods to be running when all job iterations are completed
-	WaitWhenFinished bool `yaml:"waitWhenFinished" json:"waitWhenFinished"`
+	WaitWhenFinished bool `yaml:"waitWhenFinished" json:"waitWhenFinished,omitempty"`
 	// Cleanup clean up old namespaces
-	Cleanup bool `yaml:"cleanup" json:"cleanup"`
+	Cleanup bool `yaml:"cleanup" json:"cleanup,omitempty"`
 	// NamespacedIterations create a namespace per job iteration
-	NamespacedIterations bool `yaml:"namespacedIterations" json:"namespacedIterations"`
+	NamespacedIterations bool `yaml:"namespacedIterations" json:"namespacedIterations,omitempty"`
 	// VerifyObjects verify object count after running the job
-	VerifyObjects bool `yaml:"verifyObjects" json:"verifyObjects"`
+	VerifyObjects bool `yaml:"verifyObjects" json:"verifyObjects,omitempty"`
 	// ErrorOnVerify exit when verification fails
-	ErrorOnVerify bool `yaml:"errorOnVerify" json:"errorOnVerify"`
+	ErrorOnVerify bool `yaml:"errorOnVerify" json:"errorOnVerify,omitempty"`
 	// PreLoadImages enables pulling all images before running the job
-	PreLoadImages bool `yaml:"preLoadImages" json:"preLoadImages"`
+	PreLoadImages bool `yaml:"preLoadImages" json:"preLoadImages,omitempty"`
 	// PreLoadPeriod determines the duration of the preload stage
-	PreLoadPeriod time.Duration `yaml:"preLoadPeriod" json:"preLoadPeriod"`
+	PreLoadPeriod time.Duration `yaml:"preLoadPeriod" json:"preLoadPeriod,omitempty"`
 	// NamespaceLabels add custom labels to namespaces created by kube-burner
 	NamespaceLabels map[string]string `yaml:"namespaceLabels" json:"namespaceLabels,omitempty"`
 	// Churn workload
-	Churn bool `yaml:"churn" json:"churn"`
+	Churn bool `yaml:"churn" json:"churn,omitempty"`
 	// Churn percentage
-	ChurnPercent int `yaml:"churnPercent" json:"churnPercent"`
+	ChurnPercent int `yaml:"churnPercent" json:"churnPercent,omitempty"`
 	// Churn duration
-	ChurnDuration time.Duration `yaml:"churnDuration" json:"churnDuration"`
+	ChurnDuration time.Duration `yaml:"churnDuration" json:"churnDuration,omitempty"`
 	// Churn delay between sets
-	ChurnDelay time.Duration `yaml:"churnDelay" json:"churnDelay"`
+	ChurnDelay time.Duration `yaml:"churnDelay" json:"churnDelay,omitempty"`
 }

--- a/pkg/measurements/factory.go
+++ b/pkg/measurements/factory.go
@@ -33,6 +33,7 @@ type measurementFactory struct {
 	createFuncs map[string]measurement
 	indexer     *indexers.Indexer
 	uuid        string
+	metadata    map[string]interface{}
 }
 
 type measurement interface {
@@ -46,7 +47,7 @@ var measurementMap = make(map[string]measurement)
 var kubeburnerCfg *config.GlobalConfig
 
 // NewMeasurementFactory initializes the measurement facture
-func NewMeasurementFactory(configSpec config.Spec, uuid string, indexer *indexers.Indexer) {
+func NewMeasurementFactory(configSpec config.Spec, uuid string, indexer *indexers.Indexer, metadata map[string]interface{}) {
 	kubeburnerCfg = &configSpec.GlobalConfig
 	log.Info("📈 Creating measurement factory")
 	_, restConfig, err := config.GetClientSet(0, 0)
@@ -60,6 +61,7 @@ func NewMeasurementFactory(configSpec config.Spec, uuid string, indexer *indexer
 		createFuncs: make(map[string]measurement),
 		indexer:     indexer,
 		uuid:        uuid,
+		metadata:    metadata,
 	}
 	for _, measurement := range kubeburnerCfg.Measurements {
 		if measurementFunc, exists := measurementMap[measurement.Name]; exists {

--- a/pkg/measurements/metrics/metrics.go
+++ b/pkg/measurements/metrics/metrics.go
@@ -29,17 +29,18 @@ import (
 
 // LatencyQuantiles holds the latency measurement quantiles
 type LatencyQuantiles struct {
-	QuantileName string     `json:"quantileName"`
-	UUID         string     `json:"uuid"`
-	P99          int        `json:"P99"`
-	P95          int        `json:"P95"`
-	P50          int        `json:"P50"`
-	Max          int        `json:"max"`
-	Avg          int        `json:"avg"`
-	Timestamp    time.Time  `json:"timestamp"`
-	MetricName   string     `json:"metricName"`
-	JobName      string     `json:"jobName"`
-	JobConfig    config.Job `json:"jobConfig"`
+	QuantileName string      `json:"quantileName"`
+	UUID         string      `json:"uuid"`
+	P99          int         `json:"P99"`
+	P95          int         `json:"P95"`
+	P50          int         `json:"P50"`
+	Max          int         `json:"max"`
+	Avg          int         `json:"avg"`
+	Timestamp    time.Time   `json:"timestamp"`
+	MetricName   string      `json:"metricName"`
+	JobName      string      `json:"jobName"`
+	JobConfig    config.Job  `json:"jobConfig"`
+	Metadata     interface{} `json:"metadata,omitempty"`
 }
 
 // SetQuantile adds quantile value

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -45,14 +45,15 @@ type podMetric struct {
 	containersReady        time.Time
 	ContainersReadyLatency int `json:"containersReadyLatency"`
 	podReady               time.Time
-	PodReadyLatency        int        `json:"podReadyLatency"`
-	MetricName             string     `json:"metricName"`
-	JobName                string     `json:"jobName"`
-	JobConfig              config.Job `json:"jobConfig"`
-	UUID                   string     `json:"uuid"`
-	Namespace              string     `json:"namespace"`
-	Name                   string     `json:"podName"`
-	NodeName               string     `json:"nodeName"`
+	PodReadyLatency        int         `json:"podReadyLatency"`
+	MetricName             string      `json:"metricName"`
+	JobName                string      `json:"jobName"`
+	JobConfig              config.Job  `json:"jobConfig"`
+	UUID                   string      `json:"uuid"`
+	Namespace              string      `json:"namespace"`
+	Name                   string      `json:"podName"`
+	NodeName               string      `json:"nodeName"`
+	Metadata               interface{} `json:"metadata,omitempty"`
 }
 
 type podLatency struct {
@@ -82,6 +83,7 @@ func (p *podLatency) handleCreatePod(obj interface{}) {
 				UUID:       factory.uuid,
 				JobConfig:  *jc,
 				JobName:    factory.jobConfig.Name,
+				Metadata:   factory.metadata,
 			}
 		}
 	}
@@ -163,6 +165,7 @@ func (p *podLatency) stop() (int, error) {
 		}
 	}
 	if kubeburnerCfg.IndexerConfig.Enabled {
+		log.Infof("Indexing pod latency data for job: %s", factory.jobConfig.Name)
 		p.index()
 	}
 	for _, q := range p.latencyQuantiles {
@@ -229,6 +232,7 @@ func (p *podLatency) calcQuantiles() {
 			JobName:      factory.jobConfig.Name,
 			JobConfig:    *jc,
 			MetricName:   podLatencyQuantilesMeasurement,
+			Metadata:     factory.metadata,
 		}
 		sort.Ints(v)
 		length := len(v)

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -71,8 +71,9 @@ func init() {
 func (p *podLatency) handleCreatePod(obj interface{}) {
 	now := time.Now().UTC()
 	pod := obj.(*v1.Pod)
-	jc := factory.jobConfig
-	jc.Objects = nil // metric doesn't need this data
+	jobConfig := factory.jobConfig
+	jobConfig.NamespaceLabels = nil //  metric doesn't need this data
+	jobConfig.Objects = nil         // metric doesn't need this data
 	if _, exists := p.metrics[string(pod.UID)]; !exists {
 		if strings.Contains(pod.Namespace, factory.jobConfig.Namespace) {
 			p.metrics[string(pod.UID)] = podMetric{
@@ -81,7 +82,7 @@ func (p *podLatency) handleCreatePod(obj interface{}) {
 				Name:       pod.Name,
 				MetricName: podLatencyMeasurement,
 				UUID:       factory.uuid,
-				JobConfig:  *jc,
+				JobConfig:  *jobConfig,
 				JobName:    factory.jobConfig.Name,
 				Metadata:   factory.metadata,
 			}

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -228,7 +228,8 @@ func (p *Prometheus) parseMatrix(metricName, query string, value model.Value, me
 				if val.Timestamp.Time().Before(job.End) {
 					jobName = job.Name
 					jobConfig = job.JobConfig
-					jobConfig.Objects = nil // no need to insert this into the metric.
+					jobConfig.NamespaceLabels = nil // no need to insert this into the metric
+					jobConfig.Objects = nil         // no need to insert this into the metric.
 				}
 			}
 			m := metric{

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -185,7 +185,8 @@ func (p *Prometheus) parseVector(metricName, query string, value model.Value, me
 			if v.Timestamp.Time().Before(prometheusJob.End) {
 				jobName = prometheusJob.Name
 				jobConfig = prometheusJob.JobConfig
-				jobConfig.Objects = nil // no need to insert this into the metric.
+				jobConfig.NamespaceLabels = nil // no need to insert this into the metric
+				jobConfig.Objects = nil         // no need to insert this into the metric
 			}
 		}
 		m := metric{

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -47,13 +47,13 @@ func (bat authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // NewPrometheusClient creates a prometheus struct instance with the given parameters
-func NewPrometheusClient(configSpec config.Spec, url, token, username, password, uuid string, tlsVerify bool, step time.Duration) (*Prometheus, error) {
+func NewPrometheusClient(configSpec config.Spec, url, token, username, password, uuid string, tlsVerify bool, step time.Duration, metadata map[string]interface{}) (*Prometheus, error) {
 	p := Prometheus{
 		Step:       step,
 		uuid:       uuid,
 		configSpec: configSpec,
+		metadata:   metadata,
 	}
-
 	log.Info("👽 Initializing prometheus client")
 	cfg := api.Config{
 		Address: url,
@@ -195,6 +195,7 @@ func (p *Prometheus) parseVector(metricName, query string, value model.Value, me
 			MetricName: metricName,
 			JobName:    jobName,
 			JobConfig:  jobConfig,
+			Metadata:   p.metadata,
 		}
 		for k, v := range v.Metric {
 			if k == "__name__" {
@@ -237,6 +238,7 @@ func (p *Prometheus) parseMatrix(metricName, query string, value model.Value, me
 				JobName:    jobName,
 				JobConfig:  jobConfig,
 				Timestamp:  val.Timestamp.Time(),
+				Metadata:   p.metadata,
 			}
 			for k, v := range v.Metric {
 				if k == "__name__" {

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -30,6 +30,7 @@ type Prometheus struct {
 	uuid          string
 	configSpec    config.Spec
 	JobList       []Job
+	metadata      map[string]interface{}
 }
 
 type Job struct {
@@ -64,4 +65,5 @@ type metric struct {
 	MetricName string            `json:"metricName,omitempty"`
 	JobName    string            `json:"jobName,omitempty"`
 	JobConfig  config.Job        `json:"jobConfig,omitempty"`
+	Metadata   interface{}       `json:"metadata,omitempty"`
 }

--- a/pkg/util/userMetadata.go
+++ b/pkg/util/userMetadata.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"os"
+
+	"github.com/cloud-bulldozer/kube-burner/log"
+	"gopkg.in/yaml.v3"
+)
+
+func ReadUserMetadata(inputFile string) (map[string]interface{}, error) {
+	log.Infof("Reading provided user metadata from %s", inputFile)
+	userMetadata := make(map[string]interface{})
+	f, err := os.Open(inputFile)
+	if err != nil {
+		return userMetadata, err
+	}
+	yamlDec := yaml.NewDecoder(f)
+	err = yamlDec.Decode(&userMetadata)
+	return userMetadata, err
+}

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cloud-bulldozer/kube-burner/pkg/discovery"
 	"github.com/cloud-bulldozer/kube-burner/pkg/indexers"
 	"github.com/cloud-bulldozer/kube-burner/pkg/prometheus"
+	"github.com/cloud-bulldozer/kube-burner/pkg/util"
 )
 
 const (
@@ -52,30 +53,32 @@ type WorkloadHelper struct {
 	ocpConfig       embed.FS
 	discoveryAgent  discovery.Agent
 	indexing        bool
+	userMetadata    string
 }
 
 type clusterMetadata struct {
-	MetricName       string    `json:"metricName,omitempty"`
-	UUID             string    `json:"uuid"`
-	Platform         string    `json:"platform"`
-	OCPVersion       string    `json:"ocpVersion"`
-	K8SVersion       string    `json:"k8sVersion"`
-	MasterNodesType  string    `json:"masterNodesType"`
-	WorkerNodesType  string    `json:"workerNodesType"`
-	InfraNodesType   string    `json:"infraNodesType"`
-	WorkerNodesCount int       `json:"workerNodesCount"`
-	InfraNodesCount  int       `json:"infraNodesCount"`
-	TotalNodes       int       `json:"totalNodes"`
-	SDNType          string    `json:"sdnType"`
-	Benchmark        string    `json:"benchmark"`
-	Timestamp        time.Time `json:"timestamp"`
-	EndDate          time.Time `json:"endDate"`
-	ClusterName      string    `json:"clusterName"`
-	Passed           bool      `json:"passed"`
+	MetricName       string                 `json:"metricName,omitempty"`
+	UUID             string                 `json:"uuid"`
+	Platform         string                 `json:"platform"`
+	OCPVersion       string                 `json:"ocpVersion"`
+	K8SVersion       string                 `json:"k8sVersion"`
+	MasterNodesType  string                 `json:"masterNodesType"`
+	WorkerNodesType  string                 `json:"workerNodesType"`
+	InfraNodesType   string                 `json:"infraNodesType"`
+	WorkerNodesCount int                    `json:"workerNodesCount"`
+	InfraNodesCount  int                    `json:"infraNodesCount"`
+	TotalNodes       int                    `json:"totalNodes"`
+	SDNType          string                 `json:"sdnType"`
+	Benchmark        string                 `json:"benchmark"`
+	Timestamp        time.Time              `json:"timestamp"`
+	EndDate          time.Time              `json:"endDate"`
+	ClusterName      string                 `json:"clusterName"`
+	Passed           bool                   `json:"passed"`
+	Metadata         map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // NewWorkloadHelper initializes workloadHelper
-func NewWorkloadHelper(envVars map[string]string, alerting bool, ocpConfig embed.FS, da discovery.Agent, indexing bool, timeout time.Duration) WorkloadHelper {
+func NewWorkloadHelper(envVars map[string]string, alerting bool, ocpConfig embed.FS, da discovery.Agent, indexing bool, timeout time.Duration, userMetadata string) WorkloadHelper {
 	return WorkloadHelper{
 		envVars:        envVars,
 		alerting:       alerting,
@@ -83,6 +86,7 @@ func NewWorkloadHelper(envVars map[string]string, alerting bool, ocpConfig embed
 		discoveryAgent: da,
 		timeout:        timeout,
 		indexing:       indexing,
+		userMetadata:   userMetadata,
 	}
 }
 
@@ -169,6 +173,17 @@ func (wh *WorkloadHelper) run(workload, metrics string) {
 		"k8sVersion": wh.Metadata.K8SVersion,
 		"totalNodes": wh.Metadata.TotalNodes,
 		"sdnType":    wh.Metadata.SDNType,
+	}
+	if wh.userMetadata != "" {
+		userMetadataContent, err := util.ReadUserMetadata(wh.userMetadata)
+		if err != nil {
+			log.Fatalf("Error reading provided user metadata: %v", err)
+		}
+		// Combine provided userMetadata with the regular OCP metadata
+		for k, v := range userMetadataContent {
+			metadata[k] = v
+		}
+		wh.Metadata.Metadata = userMetadataContent
 	}
 	var rc int
 	var indexer *indexers.Indexer

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -163,6 +163,13 @@ func (wh *WorkloadHelper) indexMetadata() {
 }
 
 func (wh *WorkloadHelper) run(workload, metrics string) {
+	metadata := map[string]interface{}{
+		"platform":   wh.Metadata.Platform,
+		"ocpVersion": wh.Metadata.OCPVersion,
+		"k8sVersion": wh.Metadata.K8SVersion,
+		"totalNodes": wh.Metadata.TotalNodes,
+		"sdnType":    wh.Metadata.SDNType,
+	}
 	var rc int
 	var indexer *indexers.Indexer
 	var alertM *alerting.AlertManager
@@ -184,7 +191,7 @@ func (wh *WorkloadHelper) run(workload, metrics string) {
 		}
 	}
 	configSpec.GlobalConfig.MetricsProfile = metricsProfile
-	p, err := prometheus.NewPrometheusClient(configSpec, wh.prometheusURL, wh.prometheusToken, "", "", wh.Metadata.UUID, true, 30*time.Second)
+	p, err := prometheus.NewPrometheusClient(configSpec, wh.prometheusURL, wh.prometheusToken, "", "", wh.Metadata.UUID, true, 30*time.Second, metadata)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -194,7 +201,7 @@ func (wh *WorkloadHelper) run(workload, metrics string) {
 			log.Fatal(err)
 		}
 	}
-	rc, err = burner.Run(configSpec, wh.Metadata.UUID, p, alertM, indexer, wh.timeout)
+	rc, err = burner.Run(configSpec, wh.Metadata.UUID, p, alertM, indexer, wh.timeout, metadata)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/run-ocp.sh
+++ b/test/run-ocp.sh
@@ -19,8 +19,8 @@ echo "Running node-density wrapper"
 kube-burner ocp node-density --pods-per-node=75 --pod-ready-threshold=10s --container-image=gcr.io/google_containers/pause:3.0 ${COMMON_FLAGS}
 echo "Running node-density-heavy wrapper"
 kube-burner ocp node-density-heavy --pods-per-node=75 ${COMMON_FLAGS} --qps=5 --burst=5
-echo "Running cluster-density wrapper"
-kube-burner ocp cluster-density --iterations=3 --churn-duration=2m ${COMMON_FLAGS}
+echo "Running cluster-density wrapper and user metadata"
+kube-burner ocp cluster-density --iterations=3 --churn-duration=2m ${COMMON_FLAGS} --user-metadata=user-metadata.yml
 echo "Running cluster-density wrapper w/o network-policies"
 kube-burner ocp cluster-density --iterations=2 --churn=false --uuid=${UUID} --network-policies=false
 # Disable gc and avoid metric indexing

--- a/test/user-metadata.yml
+++ b/test/user-metadata.yml
@@ -1,0 +1,1 @@
+cloud-bulldozer: true


### PR DESCRIPTION
### Description

Add clusterMetadata collected by the OCP wrapper to each indexed document. Also adds the flag --user-metadata to the ocp wrapper, index and init entrypoints.

Fixes: https://github.com/cloud-bulldozer/kube-burner/issues/250
