### PR TITLE
Use value rather than reference

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -108,7 +108,6 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int) {
 	}
 	if ex.nsObjects && !ex.Config.NamespacedIterations {
 		ns = ex.Config.Namespace
-		nsLabels["name"] = ns
 		if err = createNamespace(ClientSet, ns, nsLabels); err != nil {
 			log.Fatal(err.Error())
 		}
@@ -118,7 +117,6 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int) {
 		log.Debugf("Creating object replicas from iteration %d", i)
 		if ex.nsObjects && ex.Config.NamespacedIterations {
 			ns = fmt.Sprintf("%s-%d", ex.Config.Namespace, i)
-			nsLabels["name"] = ns
 			if err = createNamespace(ClientSet, fmt.Sprintf("%s-%d", ex.Config.Namespace, i), nsLabels); err != nil {
 				log.Error(err.Error())
 				continue

--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -30,6 +30,7 @@ func createNamespace(clientset *kubernetes.Clientset, namespaceName string, nsLa
 	ns := v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: namespaceName, Labels: nsLabels},
 	}
+
 	return RetryWithExponentialBackOff(func() (done bool, err error) {
 		_, err = clientset.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
 		if errors.IsForbidden(err) {

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -71,8 +71,8 @@ func init() {
 func (p *podLatency) handleCreatePod(obj interface{}) {
 	now := time.Now().UTC()
 	pod := obj.(*v1.Pod)
-	jobConfig := factory.jobConfig
-	jobConfig.NamespaceLabels = nil //  metric doesn't need this data
+	jobConfig := *factory.jobConfig
+	jobConfig.NamespaceLabels = nil // metric doesn't need this data
 	jobConfig.Objects = nil         // metric doesn't need this data
 	if _, exists := p.metrics[string(pod.UID)]; !exists {
 		if strings.Contains(pod.Namespace, factory.jobConfig.Namespace) {
@@ -82,7 +82,7 @@ func (p *podLatency) handleCreatePod(obj interface{}) {
 				Name:       pod.Name,
 				MetricName: podLatencyMeasurement,
 				UUID:       factory.uuid,
-				JobConfig:  *jobConfig,
+				JobConfig:  jobConfig,
 				JobName:    factory.jobConfig.Name,
 				Metadata:   factory.metadata,
 			}


### PR DESCRIPTION
Use factory.jobConfig value rather than reference before setting NamespaceLabels to nil. Also removing the "name" label from the created namespaces, I don't recall why is there, but it's not used anywhere.

- Fixes: https://github.com/cloud-bulldozer/kube-burner/issues/256
