### PR TITLE
Update deprecated pause container repository

### DIFF
--- a/cmd/kube-burner/ocp-config/cluster-density/deployment.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density/deployment.yml
@@ -19,7 +19,7 @@ spec:
       - args:
         - sleep
         - infinity
-        image: k8s.gcr.io/pause:3.1
+        image: registry.k8s.io/pause:3.1
         resources:
           requests:
             memory: "10Mi"

--- a/cmd/kube-burner/ocp-config/node-density/node-density.yml
+++ b/cmd/kube-burner/ocp-config/node-density/node-density.yml
@@ -34,4 +34,4 @@ jobs:
       - objectTemplate: pod.yml
         replicas: 1
         inputVars:
-          containerImage: gcr.io/google_containers/pause:3.1
+          containerImage: registry.k8s.io/pause:3.1

--- a/examples/workloads/api-intensive/templates/deployment.yaml
+++ b/examples/workloads/api-intensive/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         name: api-intensive-{{.Replica}}
     spec:
       containers:
-      - image: k8s.gcr.io/pause:3.1
+      - image: registry.k8s.io/pause:3.1
         name: api-intensive-{{.Replica}}
         resources:
           requests:

--- a/examples/workloads/api-intensive/templates/deployment_patch_add_pod_2.yaml
+++ b/examples/workloads/api-intensive/templates/deployment_patch_add_pod_2.yaml
@@ -4,7 +4,7 @@ spec:
   template:
     spec:
       containers:
-      - image: k8s.gcr.io/pause:3.1
+      - image: registry.k8s.io/pause:3.1
         name: api-intensive-2
         resources:
           requests:

--- a/examples/workloads/cluster-density/templates/deployment.yml
+++ b/examples/workloads/cluster-density/templates/deployment.yml
@@ -21,7 +21,7 @@ spec:
       - args:
         - sleep
         - infinity
-        image: k8s.gcr.io/pause:3.1
+        image: registry.k8s.io/pause:3.1
         volumeMounts:
         - name: secret-1
           mountPath: /secret1

--- a/examples/workloads/kubelet-density/kubelet-density.yml
+++ b/examples/workloads/kubelet-density/kubelet-density.yml
@@ -28,4 +28,4 @@ jobs:
       - objectTemplate: templates/pod.yml
         replicas: 1
         inputVars:
-          containerImage: gcr.io/google_containers/pause-amd64:3.0
+          containerImage: registry.k8s.io/pause:3.1


### PR DESCRIPTION
### Description

According to this k8s announcement:

>Legacy k8s.gcr.io container image registry will be frozen in early April 2023
k8s.gcr.io image registry will be frozen from the 3rd of April 2023.
Images for Kubernetes 1.27 will not available in the k8s.gcr.io image registry.
Please read our [announcement](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/) for more details. 

