### PR TITLE
Fix OCP command for 1.4.3

### DIFF
--- a/cmd/kube-burner/ocp.go
+++ b/cmd/kube-burner/ocp.go
@@ -41,6 +41,7 @@ func openShiftCmd() *cobra.Command {
 	var wh workloads.WorkloadHelper
 	esServer := ocpCmd.PersistentFlags().String("es-server", "", "Elastic Search endpoint")
 	esIndex := ocpCmd.PersistentFlags().String("es-index", "", "Elastic Search index")
+	indexing := ocpCmd.PersistentFlags().Bool("indexing", true, "Enable indexing")
 	metricsEndpoint := ocpCmd.PersistentFlags().String("metrics-endpoint", "", "YAML file with a list of metric endpoints")
 	alerting := ocpCmd.PersistentFlags().Bool("alerting", true, "Enable alerting")
 	uuid := ocpCmd.PersistentFlags().String("uuid", uid.NewV4().String(), "Benchmark UUID")
@@ -53,17 +54,16 @@ func openShiftCmd() *cobra.Command {
 	ocpCmd.MarkFlagsRequiredTogether("es-server", "es-index")
 	ocpCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		rootCmd.PersistentPreRun(cmd, args)
-		indexing := *esServer != ""
 		envVars := map[string]string{
 			"ES_SERVER": strings.TrimSuffix(*esServer, "/"),
 			"ES_INDEX":  *esIndex,
 			"QPS":       fmt.Sprintf("%d", *qps),
 			"BURST":     fmt.Sprintf("%d", *burst),
-			"INDEXING":  fmt.Sprintf("%v", indexing),
+			"INDEXING":  fmt.Sprintf("%v", *indexing),
 			"GC":        fmt.Sprintf("%v", *gc),
 		}
 		discoveryAgent := discovery.NewDiscoveryAgent()
-		wh = workloads.NewWorkloadHelper(envVars, *alerting, OCPConfig, discoveryAgent, indexing, *timeout, *metricsEndpoint, *userMetadata)
+		wh = workloads.NewWorkloadHelper(envVars, *alerting, OCPConfig, discoveryAgent, *indexing, *timeout, *metricsEndpoint, *userMetadata)
 		wh.Metadata.UUID = *uuid
 		if *extract {
 			if err := wh.ExtractWorkload(cmd.Name(), workloads.MetricsProfileMap[cmd.Name()]); err != nil {

--- a/cmd/kube-burner/ocp.go
+++ b/cmd/kube-burner/ocp.go
@@ -41,7 +41,7 @@ func openShiftCmd() *cobra.Command {
 	var wh workloads.WorkloadHelper
 	esServer := ocpCmd.PersistentFlags().String("es-server", "", "Elastic Search endpoint")
 	esIndex := ocpCmd.PersistentFlags().String("es-index", "", "Elastic Search index")
-	indexing := ocpCmd.PersistentFlags().Bool("indexing", false, "Enable indexing")
+	indexingFlag := ocpCmd.PersistentFlags().Bool("indexing", false, "Enable indexing")
 	metricsEndpoint := ocpCmd.PersistentFlags().String("metrics-endpoint", "", "YAML file with a list of metric endpoints")
 	alerting := ocpCmd.PersistentFlags().Bool("alerting", true, "Enable alerting")
 	uuid := ocpCmd.PersistentFlags().String("uuid", uid.NewV4().String(), "Benchmark UUID")
@@ -54,16 +54,17 @@ func openShiftCmd() *cobra.Command {
 	ocpCmd.MarkFlagsRequiredTogether("es-server", "es-index")
 	ocpCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		rootCmd.PersistentPreRun(cmd, args)
+		indexing := *esServer != "" || *indexingFlag
 		envVars := map[string]string{
 			"ES_SERVER": strings.TrimSuffix(*esServer, "/"),
 			"ES_INDEX":  *esIndex,
 			"QPS":       fmt.Sprintf("%d", *qps),
 			"BURST":     fmt.Sprintf("%d", *burst),
-			"INDEXING":  fmt.Sprintf("%v", *indexing),
+			"INDEXING":  fmt.Sprintf("%v", indexing),
 			"GC":        fmt.Sprintf("%v", *gc),
 		}
 		discoveryAgent := discovery.NewDiscoveryAgent()
-		wh = workloads.NewWorkloadHelper(envVars, *alerting, OCPConfig, discoveryAgent, *indexing, *timeout, *metricsEndpoint, *userMetadata)
+		wh = workloads.NewWorkloadHelper(envVars, *alerting, OCPConfig, discoveryAgent, indexing, *timeout, *metricsEndpoint, *userMetadata)
 		wh.Metadata.UUID = *uuid
 		if *extract {
 			if err := wh.ExtractWorkload(cmd.Name(), workloads.MetricsProfileMap[cmd.Name()]); err != nil {

--- a/cmd/kube-burner/ocp.go
+++ b/cmd/kube-burner/ocp.go
@@ -41,7 +41,7 @@ func openShiftCmd() *cobra.Command {
 	var wh workloads.WorkloadHelper
 	esServer := ocpCmd.PersistentFlags().String("es-server", "", "Elastic Search endpoint")
 	esIndex := ocpCmd.PersistentFlags().String("es-index", "", "Elastic Search index")
-	indexing := ocpCmd.PersistentFlags().Bool("indexing", true, "Enable indexing")
+	indexing := ocpCmd.PersistentFlags().Bool("indexing", false, "Enable indexing")
 	metricsEndpoint := ocpCmd.PersistentFlags().String("metrics-endpoint", "", "YAML file with a list of metric endpoints")
 	alerting := ocpCmd.PersistentFlags().Bool("alerting", true, "Enable alerting")
 	uuid := ocpCmd.PersistentFlags().String("uuid", uid.NewV4().String(), "Benchmark UUID")

--- a/docs/ocp.md
+++ b/docs/ocp.md
@@ -24,6 +24,7 @@ Flags:
       --extract                   Extract workload in the current directory
       --gc                        Garbage collect created namespaces (default true)
   -h, --help                      help for ocp
+      --indexing                  Enable indexing (default false)
       --metrics-endpoint string   YAML file with a list of metric endpoints
       --qps int                   QPS (default 20)
       --timeout duration          Benchmark timeout (default 2h0m0s)
@@ -49,7 +50,7 @@ $ kube-burner ocp node-density --pods-per-node=100
 Running cluster-density with multiple endpoints support
 
 ```console
-$ kube-burner ocp cluster-density --iterations=1 --churn-duration=2m0s --es-index kube-burner --es-server https://www.esurl.com:443 --metrics-endpoint metrics-endpoints.yaml
+$ kube-burner ocp cluster-density --iterations=1 --churn-duration=2m0s --indexing=true --es-index kube-burner --es-server https://www.esurl.com:443 --metrics-endpoint metrics-endpoints.yaml
 ```
 
 

--- a/docs/ocp.md
+++ b/docs/ocp.md
@@ -50,7 +50,7 @@ $ kube-burner ocp node-density --pods-per-node=100
 Running cluster-density with multiple endpoints support
 
 ```console
-$ kube-burner ocp cluster-density --iterations=1 --churn-duration=2m0s --indexing=true --es-index kube-burner --es-server https://www.esurl.com:443 --metrics-endpoint metrics-endpoints.yaml
+$ kube-burner ocp cluster-density --iterations=1 --churn-duration=2m0s --es-index kube-burner --es-server https://www.esurl.com:443 --metrics-endpoint metrics-endpoints.yaml
 ```
 
 

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -211,7 +211,7 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 	if wh.indexing {
 		indexer, err = indexers.NewIndexer(configSpec)
 		if err != nil {
-			log.Fatal("%v Indexer: %v", configSpec.GlobalConfig.IndexerConfig.Type, err.Error())
+			log.Fatalf("%v Indexer: %v", configSpec.GlobalConfig.IndexerConfig.Type, err.Error())
 		}
 	}
 	configSpec.GlobalConfig.MetricsProfile = metricsProfile

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -214,7 +214,6 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 			log.Fatalf("%v Indexer: %v", configSpec.GlobalConfig.IndexerConfig.Type, err.Error())
 		}
 	}
-	configSpec.GlobalConfig.MetricsProfile = metricsProfile
 	if wh.metricsEndpoint != "" {
 		metrics.DecodeMetricsEndpoint(wh.metricsEndpoint, &metricsEndpoints)
 	} else {

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -221,6 +221,7 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 		metricsEndpoints = append(metricsEndpoints, prometheus.MetricEndpoint{
 			Endpoint:     wh.prometheusURL,
 			AlertProfile: alertsProfile,
+			Profile:      metricsProfile,
 			Token:        wh.prometheusToken,
 		})
 	}

--- a/test/cluster-density-local-indexer.yml
+++ b/test/cluster-density-local-indexer.yml
@@ -1,0 +1,55 @@
+---
+global:
+  gc: {{.GC}}
+  indexerConfig:
+    enabled: {{.INDEXING}}
+    metricsDirectory: collected-metrics
+    createTarball: true
+    tarballName: collected-metrics.tar.gz
+    type: local
+  measurements:
+    - name: podLatency
+jobs:
+  - name: cluster-density
+    namespace: cluster-density
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: true
+    podWait: false
+    waitWhenFinished: true
+    preLoadImages: true
+    preLoadPeriod: 30s
+    churn: {{.CHURN}}
+    churnDuration: {{.CHURN_DURATION}}
+    churnPercent: {{.CHURN_PERCENT}}
+    churnDelay: {{.CHURN_DELAY}}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+
+      - objectTemplate: imagestream.yml
+        replicas: 1
+
+      - objectTemplate: build.yml
+        replicas: 1
+
+      - objectTemplate: deployment.yml
+        replicas: 5
+        inputVars:
+          podReplicas: 2
+
+      - objectTemplate: service.yml
+        replicas: 5
+
+      - objectTemplate: route.yml
+        replicas: 1
+
+      - objectTemplate: secret.yml
+        replicas: 10
+
+      - objectTemplate: configmap.yml
+        replicas: 10

--- a/test/run-ocp.sh
+++ b/test/run-ocp.sh
@@ -16,7 +16,7 @@ die() {
 UUID=$(uuidgen)
 ES_SERVER="https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com/"
 ES_INDEX="kube-burner-ocp"
-COMMON_FLAGS="--es-server=${ES_SERVER} --es-index=${ES_INDEX} --alerting=true --uuid=${UUID} --qps=5 --burst=5"
+COMMON_FLAGS="--indexing=true --es-server=${ES_SERVER} --es-index=${ES_INDEX} --alerting=true --uuid=${UUID} --qps=5 --burst=5"
 
 echo "Running node-density wrapper"
 kube-burner ocp node-density --pods-per-node=75 --pod-ready-threshold=10s --container-image=gcr.io/google_containers/pause:3.0 ${COMMON_FLAGS}

--- a/test/run-ocp.sh
+++ b/test/run-ocp.sh
@@ -44,6 +44,9 @@ trap 'die' ERR
 
 # Run OCP test for local indexer - this will overwrite existing cluster-density.yml file
 echo "Running cluster-density wrapper with local indexer"
-mv cluster-density-local-indexer.yml cluster-density.yml
+cp cluster-density-local-indexer.yml cluster-density.yml
 kube-burner ocp cluster-density --iterations=2 --churn=false --indexing=true
-[[ ! -f "collected-metrics.tar.gz" ]] && die "Local indexer did not create collected-metrics.tar.gz file"
+if [[ ! -f "collected-metrics.tar.gz" ]]
+then
+  die "Local indexer did not create collected-metrics.tar.gz file"
+fi

--- a/test/run-ocp.sh
+++ b/test/run-ocp.sh
@@ -16,7 +16,7 @@ die() {
 UUID=$(uuidgen)
 ES_SERVER="https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com/"
 ES_INDEX="kube-burner-ocp"
-COMMON_FLAGS="--indexing=true --es-server=${ES_SERVER} --es-index=${ES_INDEX} --alerting=true --uuid=${UUID} --qps=5 --burst=5"
+COMMON_FLAGS="--es-server=${ES_SERVER} --es-index=${ES_INDEX} --alerting=true --uuid=${UUID} --qps=5 --burst=5"
 
 echo "Running node-density wrapper"
 kube-burner ocp node-density --pods-per-node=75 --pod-ready-threshold=10s --container-image=gcr.io/google_containers/pause:3.0 ${COMMON_FLAGS}


### PR DESCRIPTION
### Description

This PR is fixing two problems discovered in version 1.4.3.

1. Adding indexer option to define if indexer should be used or not (default: false)
2. Setting correct metrics configuration file

### Fixes

**1. Local indexer**

If we are using a local indexer, the problem is that the indexer instance will not be created, and `kube-burner` will panic.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x230f9b4]

goroutine 78 [running]:
github.com/cloud-bulldozer/kube-burner/pkg/burner.indexjobSummaryInfo(0x0, {0x7ff7bfeff635, 0x38}, 0x4040ede1d2178f69, {0x14, 0x0, 0x0, {0xc00057ced0, 0xf}, {0xc0003bc000, ...}, ...}, ...)
	/home/runner/work/kube-burner/kube-burner/pkg/burner/metadata.go:51 +0x214
github.com/cloud-bulldozer/kube-burner/pkg/burner.Run.func1()
	/home/runner/work/kube-burner/kube-burner/pkg/burner/job.go:168 +0x1449
created by github.com/cloud-bulldozer/kube-burner/pkg/burner.Run
	/home/runner/work/kube-burner/kube-burner/pkg/burner/job.go:87 +0x3ed
```

The reason for this problem is that usage of the indexer is determined by the existence of the Elastic endpoint option. And that option does not exist for local indexer.

The proposed solution is an independent command option that allows us to enable/disable the indexer per test execution.

**2. Empty metrics profile**
 
With some changes in 1.4.3, information about the default metrics profile is not propagated, and the metrics profile is always empty.

Added changes will propagate the metrics profile provided in a function call.

