### PR TITLE
Add prometheus related metrics to ocp wrapper

### DIFF
--- a/cmd/kube-burner/ocp-config/metrics-aggregated.yml
+++ b/cmd/kube-burner/ocp-config/metrics-aggregated.yml
@@ -135,3 +135,11 @@
 
 - query: sum(kube_node_status_condition{status="true"}) by (condition)
   metricName: nodeStatus
+
+# Prometheus metrics
+
+- query: openshift:prometheus_tsdb_head_series:sum{job="prometheus-k8s"}
+  metricName: prometheus-timeseriestotal
+
+- query: openshift:prometheus_tsdb_head_samples_appended_total:sum{job="prometheus-k8s"}
+  metricName: prometheus-ingestionrate

--- a/cmd/kube-burner/ocp-config/metrics.yml
+++ b/cmd/kube-burner/ocp-config/metrics.yml
@@ -128,3 +128,11 @@
 
 - query: sum(kube_node_status_condition{status="true"}) by (condition)
   metricName: nodeStatus
+
+# Prometheus metrics
+
+- query: openshift:prometheus_tsdb_head_series:sum{job="prometheus-k8s"}
+  metricName: prometheus-timeseriestotal
+
+- query: openshift:prometheus_tsdb_head_samples_appended_total:sum{job="prometheus-k8s"}
+  metricName: prometheus-ingestionrate


### PR DESCRIPTION
With every release we seem to be adding more metrics and as a result more timeseries, samples and datapoints per minute to prometheus. It would be beneficial to maintain this data for historical comparisons and RCAing prometheus issues.

### Description

### Fixes
