### PR TITLE
Use unauthenticated postgres image

### DIFF
--- a/cmd/kube-burner/ocp-config/node-density-heavy/postgres-deployment.yml
+++ b/cmd/kube-burner/ocp-config/node-density-heavy/postgres-deployment.yml
@@ -21,7 +21,7 @@ spec:
                 operator: DoesNotExist
       containers:
       - name: postgresql
-        image: registry.redhat.io/rhel8/postgresql-10@sha256:4b912c80085b88a03309aeb7907efcc29dd3342fa3952b6ea067afb1914bfe53
+        image: registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest
         ports:
         - containerPort: 5432
           protocol: TCP


### PR DESCRIPTION
Maybe a good idea to use unauthenticated images as registry.redhat.io requires auth. It is possible to install an OCP cluster without the token for that registry (ARO for example calls out pullsecret as option in its docs), so we should handle that case.

```
Failed to pull image "registry.redhat.io/rhel8/postgresql-10@sha256:4b912c80085b88a03309aeb7907efcc29dd3342fa3952b6ea067afb1914bfe53": rpc error: code = Unknown desc = unable to retrieve auth token: invalid username/password: unauthorized: Please login to the Red Hat Registry using your Customer Portal credentials. Further instructions can be found here: https://access.redhat.com/RegistryAuthentication``` 

Alternatives
1. Maintain image on cloud-bulldozer quay org
2. Enforce having the auth token as a pre-req for this test 
