### PR TITLE
Replace IsForbidden by IsUnauthorized

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -220,7 +220,7 @@ func createRequest(gvr schema.GroupVersionResource, ns string, obj *unstructured
 			uns, err = dynamicClient.Resource(gvr).Create(context.TODO(), obj, metav1.CreateOptions{})
 		}
 		if err != nil {
-			if kerrors.IsForbidden(err) {
+			if kerrors.IsUnauthorized(err) {
 				log.Fatalf("Authorization error creating %s/%s: %s", obj.GetKind(), obj.GetName(), err)
 				return true, err
 			} else if kerrors.IsAlreadyExists(err) {


### PR DESCRIPTION
### Description

We were checking IsForbidden rather than IsUnauthorized. According to the client-go docs they have different meanings:

Forbidden:
```shell
	// StatusReasonForbidden means the server can be reached and understood the request, but refuses
	// to take any further action.  It is the result of the server being configured to deny access for some reason
	// to the requested resource by the client.
	// Details (optional):
	//   "kind" string - the kind attribute of the forbidden resource
	//                   on some operations may differ from the requested
	//                   resource.
	//   "id"   string - the identifier of the forbidden resource
	// Status code 403
	StatusReasonForbidden StatusReason = "Forbidden"
```

Unauthorized:
```shell
	// StatusReasonUnauthorized means the server can be reached and understood the request, but requires
	// the user to present appropriate authorization credentials (identified by the WWW-Authenticate header)
	// in order for the action to be completed. If the user has specified credentials on the request, the
	// server considers them insufficient.
	// Status code 401
	StatusReasonUnauthorized StatusReason = "Unauthorized"
```

If a IsForbidden error happens now, it will be retried.


Fixes: https://github.com/cloud-bulldozer/kube-burner/issues/277
