### PR TITLE
Improve platform discovery logic

### DIFF
--- a/pkg/discovery/types.go
+++ b/pkg/discovery/types.go
@@ -18,6 +18,17 @@ type InfraObj struct {
 	Status struct {
 		InfrastructureName string `json:"infrastructureName"`
 		Platform           string `json:"platform"`
+		Type               string `json:"type"`
+		PlatformStatus     struct {
+			Aws struct {
+				Region       string `json:"region"`
+				ResourceTags []struct {
+					Key   string `json:"key"`
+					Value string `json:"value"`
+				} `json:"resourceTags"`
+			} `json:"aws"`
+			Type string `json:"type"`
+		} `yaml:"platformStatus"`
 	} `json:"status"`
 }
 

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -131,6 +131,11 @@ func (wh *WorkloadHelper) GatherMetadata() error {
 	}
 	wh.Metadata.MetricName = metadataMetricName
 	wh.Metadata.Platform = infra.Status.Platform
+	for _, v := range infra.Status.PlatformStatus.Aws.ResourceTags {
+		if v.Key == "red-hat-clustertype" {
+			wh.Metadata.Platform = v.Value
+		}
+	}
 	wh.Metadata.ClusterName = infra.Status.InfrastructureName
 	wh.Metadata.K8SVersion = version.K8sVersion
 	wh.Metadata.OCPVersion = version.OcpVersion


### PR DESCRIPTION
### Description

Thanks to this new logic we can discover the platform from rosa based clusters.
Rosa infrastructure object:
```yaml 
apiVersion: config.openshift.io/v1
kind: Infrastructure
metadata:
  annotations:
    include.release.openshift.io/ibm-cloud-managed: "true"
    include.release.openshift.io/self-managed-high-availability: "true"
    include.release.openshift.io/single-node-developer: "true"
    release.openshift.io/create-only: "true"
  creationTimestamp: "2023-04-03T09:44:06Z"
  generation: 2
  labels:
    hypershift.openshift.io/managed: "true"
  name: cluster
  ownerReferences:
  - apiVersion: config.openshift.io/v1
    kind: ClusterVersion
    name: version
    uid: 722304ba-e77a-46e7-bb5b-9a5ca3da644c
  resourceVersion: "1169"
  uid: 901329cb-5d69-4281-8943-9a6a7791dbc2
spec:
  cloudConfig:
    name: ""
  platformSpec:
    aws: {}
    type: AWS
status:
  apiServerInternalURI:  <truncated>
  apiServerURL:  <truncated>
  controlPlaneTopology: External
  etcdDiscoveryDomain: <truncated>
  infrastructureName: 22s4vo9q10sfgo0v8g8f4n010ihc54ff
  infrastructureTopology: HighlyAvailable
  platform: AWS
  platformStatus:
    aws:
      region: us-east-2
      resourceTags:
      - key: api.openshift.com/environment
        value: staging
      - key: api.openshift.com/id
        value:  <truncated>
      - key: api.openshift.com/legal-entity-id
        value:  <truncated>
      - key: api.openshift.com/name
        value: mrnd-logg
      - key: red-hat-clustertype
        value: rosa
      - key: red-hat-managed
        value: "true"
    type: AWS
```

The infrastructure object from ARO clusters is pretty incomplete though...

```yaml
apiVersion: config.openshift.io/v1
kind: Infrastructure
metadata:
  creationTimestamp: "2023-04-05T10:14:59Z"
  generation: 1
  name: cluster
  resourceVersion: "440"
  uid: be6d1168-5b4a-4784-862b-76f45a4d4d87
spec:
  cloudConfig:
    key: config
    name: cloud-provider-config
  platformSpec:
    type: Azure
status:
  apiServerInternalURI: <truncated>
  apiServerURL:  <truncated>
  controlPlaneTopology: HighlyAvailable
  etcdDiscoveryDomain: ""
  infrastructureName: vzm-test-v54tl
  infrastructureTopology: HighlyAvailable
  platform: Azure
  platformStatus:
    azure:
      cloudName: AzurePublicCloud
      networkResourceGroupName: vzmRG
      resourceGroupName: aro-d1osnb8u
    type: Azure
```


