### PR TITLE
Revert "Use unauthenticated postgres image (#276)"

### DIFF
--- a/cmd/kube-burner/ocp-config/node-density-heavy/postgres-deployment.yml
+++ b/cmd/kube-burner/ocp-config/node-density-heavy/postgres-deployment.yml
@@ -21,7 +21,7 @@ spec:
                 operator: DoesNotExist
       containers:
       - name: postgresql
-        image: registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest
+        image: registry.redhat.io/rhel8/postgresql-10@sha256:4b912c80085b88a03309aeb7907efcc29dd3342fa3952b6ea067afb1914bfe53
         ports:
         - containerPort: 5432
           protocol: TCP


### PR DESCRIPTION
The OCP clusters we interact with, normally have permissions to pull this image.

This reverts commit ad40e053d0c6d2db3346bb6349869d11f3e90092.

- Fixes: #298
