### PR TITLE
Remove incorrect job duration message

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -114,7 +114,6 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int) {
 			log.Fatal(err.Error())
 		}
 	}
-	start := time.Now().Round(time.Second)
 	// We have to sum 1 since the iterations start from 1
 	iterationProgress := (iterationEnd - iterationStart + 1) / 10
 	percent := 1
@@ -181,7 +180,6 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int) {
 		}
 		wg.Wait()
 	}
-	log.Infof("Finished the create job in %v", time.Since(start).Round(time.Second))
 }
 
 // Simple integer division on the iteration allows us to batch iterations into

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -155,16 +155,16 @@ func Run(configSpec config.Spec, uuid string, prometheusClients []*prometheus.Pr
 			jobList[jobPosition].End = time.Now().UTC()
 			prometheusJob.End = jobList[jobPosition].End
 			prometheusJob.JobConfig = job.Config
-			elapsedTime := prometheusJob.End.Sub(prometheusJob.Start).Seconds()
+			elapsedTime := prometheusJob.End.Sub(prometheusJob.Start).Round(time.Second)
 			// Don't append to Prometheus jobList when prometheus it's not initialized
 			if len(prometheusClients) > 0 {
 				prometheusJobList = append(prometheusJobList, prometheusJob)
 			}
-			log.Infof("Job %s took %.2f seconds", job.Config.Name, elapsedTime)
+			log.Infof("Job %s took %v", job.Config.Name, elapsedTime)
 		}
 		if globalConfig.IndexerConfig.Enabled {
 			for _, job := range jobList {
-				elapsedTime := job.End.Sub(job.Start).Seconds()
+				elapsedTime := job.End.Sub(job.Start).Round(time.Second).Seconds()
 				indexjobSummaryInfo(indexer, uuid, elapsedTime, job.Config, job.Start, metadata)
 			}
 		}


### PR DESCRIPTION
### Description

Removing job duration log message from `create.go` and print rounded duration in seconds rather than seconds with decimals

Fixes: https://github.com/cloud-bulldozer/kube-burner/issues/312
