### PR TITLE
Enable waiting on global objects

### DIFF
--- a/pkg/burner/waiters.go
+++ b/pkg/burner/waiters.go
@@ -23,6 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -35,7 +36,7 @@ func (ex *Executor) waitForObjects(ns string) {
 		if obj.Wait {
 			wg.Add(1)
 			if obj.WaitOptions.ForCondition != "" {
-				go waitForCondition(obj.gvr, ns, obj.WaitOptions.ForCondition, ex.MaxWaitTimeout, &wg)
+				go waitForCondition(obj.gvr, ns, obj.WaitOptions.ForCondition, ex.MaxWaitTimeout, obj.Namespaced, &wg)
 			} else {
 				switch obj.kind {
 				case "Deployment":
@@ -222,22 +223,29 @@ func waitForJob(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 		Version:  "v1",
 		Resource: "jobs",
 	}
-	verifyCondition(gvr, ns, "Complete", maxWaitTimeout)
+	verifyCondition(gvr, ns, "Complete", maxWaitTimeout, true)
 }
 
 func waitForCondition(gvr schema.GroupVersionResource, ns, condition string, maxWaitTimeout time.Duration,
-	wg *sync.WaitGroup) {
+	namespaced bool, wg *sync.WaitGroup) {
 	defer wg.Done()
-	verifyCondition(gvr, ns, condition, maxWaitTimeout)
+	verifyCondition(gvr, ns, condition, maxWaitTimeout, namespaced)
 }
 
-func verifyCondition(gvr schema.GroupVersionResource, ns, condition string, maxWaitTimeout time.Duration) {
+func verifyCondition(gvr schema.GroupVersionResource, ns, condition string, maxWaitTimeout time.Duration, namespaced bool) {
 	var uObj types.UnstructuredContent
 	wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
-		objs, err := waitDynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
+
+		var objs *unstructured.UnstructuredList
+		if namespaced {
+			objs, err = waitDynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
+		} else {
+			objs, err = waitDynamicClient.Resource(gvr).List(context.TODO(), metav1.ListOptions{})
+		}
 		if err != nil {
 			return false, err
 		}
+
 	VERIFY:
 		for _, obj := range objs.Items {
 			jsonBuild, err := obj.MarshalJSON()
@@ -267,7 +275,7 @@ func waitForVM(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 		Version:  types.KubevirtAPIVersion,
 		Resource: types.VirtualMachineResource,
 	}
-	verifyCondition(vmGVR, ns, "Ready", maxWaitTimeout)
+	verifyCondition(vmGVR, ns, "Ready", maxWaitTimeout, true)
 }
 
 func waitForVMI(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
@@ -277,7 +285,7 @@ func waitForVMI(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {
 		Version:  types.KubevirtAPIVersion,
 		Resource: types.VirtualMachineInstanceResource,
 	}
-	verifyCondition(vmiGVR, ns, "Ready", maxWaitTimeout)
+	verifyCondition(vmiGVR, ns, "Ready", maxWaitTimeout, true)
 }
 
 func waitForVMIRS(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGroup) {


### PR DESCRIPTION
### Description

The wait logic has been updated to support globally scoped objects. 

I hit this problem while working with Crossplane XRDs which have a global scope. 

Fixes #337
