### PR TITLE
object templates dirname is taken from config file

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -80,6 +80,9 @@ Each object element supports the following parameters:
 | `wait`                 | Wait for object to be ready                                       | Boolean | true    |
 | `waitOptions`          | Customize how to wait for object to be ready                      | Object  | {}       |
 
+!!! info
+    The `objectTemplate` is a relative path to the main configuration file and not to the users's cwd
+
 !!! warning
     Kube-burner is only able to wait for a subset of resources, unless `waitOptions` are specified.
 

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math"
 	"math/rand"
+	"path"
 	"strconv"
 	"sync"
 	"time"
@@ -56,20 +57,21 @@ func setupCreateJob(jobConfig config.Job) Executor {
 			log.Warnf("Object template %s has replicas %d < 1, skipping", o.ObjectTemplate, o.Replicas)
 			continue
 		}
-		log.Debugf("Rendering template: %s", o.ObjectTemplate)
-		f, err := util.ReadConfig(o.ObjectTemplate)
+		templatePath := path.Join(config.CfgDir, o.ObjectTemplate)
+		log.Debugf("Rendering template: %s", templatePath)
+		f, err := util.ReadConfig(templatePath)
 		if err != nil {
-			log.Fatalf("Error reading template %s: %s", o.ObjectTemplate, err)
+			log.Fatalf("Error reading template %s: %s", templatePath, err)
 		}
 		t, err := io.ReadAll(f)
 		if err != nil {
-			log.Fatalf("Error reading template %s: %s", o.ObjectTemplate, err)
+			log.Fatalf("Error reading template %s: %s", templatePath, err)
 		}
 		// Deserialize YAML
 		uns := &unstructured.Unstructured{}
 		cleanTemplate, err := prepareTemplate(t)
 		if err != nil {
-			log.Fatalf("Error preparing template %s: %s", o.ObjectTemplate, err)
+			log.Fatalf("Error preparing template %s: %s", templatePath, err)
 		}
 		_, gvk := yamlToUnstructured(cleanTemplate, uns)
 		mapping, err := mapper.RESTMapping(gvk.GroupKind())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,6 +97,11 @@ func (j *Job) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Parse parses a configuration file
 func Parse(c string, jobsRequired bool) (Spec, error) {
+	cfgAbs, err := filepath.Abs(c)
+	if err != nil {
+		return configSpec, err
+	}
+	CfgDir = filepath.Dir(cfgAbs)
 	f, err := util.ReadConfig(c)
 	if err != nil {
 		return configSpec, fmt.Errorf("Error reading configuration file %s: %s", c, err)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -24,6 +24,9 @@ import (
 // JobType type of job
 type JobType string
 
+// Config file directory
+var CfgDir string
+
 const (
 	// CreationJob used to create objects
 	CreationJob JobType = "create"


### PR DESCRIPTION
Thanks to this update, kube-burner will build the object templates absolute path using the directory name of the configuration file

Fixes: #332 
