### PR TITLE
Default iterations per namespace for cni heavy

### DIFF
--- a/cmd/kube-burner/ocp-config/node-density-cni/node-density-cni.yml
+++ b/cmd/kube-burner/ocp-config/node-density-cni/node-density-cni.yml
@@ -14,7 +14,8 @@ jobs:
     jobIterations: {{.JOB_ITERATIONS}}
     qps: {{.QPS}}
     burst: {{.BURST}}
-    namespacedIterations: false
+    namespacedIterations: true
+    iterationsPerNamespace: 1000
     podWait: false
     waitWhenFinished: true
     preLoadImages: true

--- a/cmd/kube-burner/ocp-config/node-density-heavy/node-density-heavy.yml
+++ b/cmd/kube-burner/ocp-config/node-density-heavy/node-density-heavy.yml
@@ -18,7 +18,8 @@ jobs:
     jobIterations: {{.JOB_ITERATIONS}}
     qps: {{.QPS}}
     burst: {{.BURST}}
-    namespacedIterations: false
+    namespacedIterations: true
+    iterationsPerNamespace: 1000
     podWait: false
     waitWhenFinished: true
     preLoadImages: true

--- a/docs/ocp.md
+++ b/docs/ocp.md
@@ -126,9 +126,13 @@ This workload is meant to fill with pause pods all the worker nodes from the clu
 
 It creates two Deployments, a client/curl and a server/nxing, and 1 Service backed by the previous server Pods. The client application has configured an startupProbe that makes requests to the previous Service every second with a timeout of 600s.
 
+Note: this workload calculates the number of iterations to create from the number of nodes and desired pods per node.  In order to keep the test scalable and performant, chunks of 1000 iterations will by broken into separate namespaces, using the config variable `iterationsPerNamespace`.
+
 ### node-density-heavy
 
 Creates two Deployments, a postgresql database and a simple client that performs periodic insert queries (configured through liveness and readiness probes) on the previous database and a Service that is used by the client to reach the database.
+
+Note: this workload calculates the number of iterations to create from the number of nodes and desired pods per node.  In order to keep the test scalable and performant, chunks of 1000 iterations will by broken into separate namespaces, using the config variable `iterationsPerNamespace`.
 
 ## Reporting mode
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -45,6 +45,7 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | `jobIterations`        | How many times to execute the job                                                | Integer | 0       |
 | `namespace`            | Namespace base name to use                                                       | String  | ""      |
 | `namespacedIterations` | Whether to create a namespace per job iteration                                  | Boolean | true    |
+| `iterationsPerNamespace` | The maximum number of `jobIterations` to create in a single namespace. Important for node-density workloads that create Services.                                  | Integer | 1    |
 | `cleanup`              | Cleanup clean up old namespaces                                                  | Boolean | true    |
 | `podWait`              | Wait for all pods to be running before moving forward to the next job iteration  | Boolean | false   |
 | `waitWhenFinished`     | Wait for all pods to be running when all iterations are completed                | Boolean | true    |


### PR DESCRIPTION
### Fixes ...

... failures running node-density-heavy and node-density-cni @245ppn on clusters with more than 24 worker nodes.