### PR TITLE
fixing indexing issues when es-config is not passed in CLI for ocp

### DIFF
--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -174,8 +174,8 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if wh.indexing {
-		indexerConfig := configSpec.GlobalConfig.IndexerConfig
+	indexerConfig := configSpec.GlobalConfig.IndexerConfig
+	if indexerConfig.Type != "" {
 		log.Infof("📁 Creating indexer: %s", indexerConfig.Type)
 		indexer, err = indexers.NewIndexer(indexerConfig)
 		if err != nil {


### PR DESCRIPTION
### Description
Fixing indexing issues when es-config is not passed in CLI for ocp

### Fixes: https://github.com/cloud-bulldozer/kube-burner/issues/351
