### PR TITLE
Add iterations-per-namespace as cli option

### DIFF
--- a/cmd/kube-burner/ocp-config/node-density-cni/node-density-cni.yml
+++ b/cmd/kube-burner/ocp-config/node-density-cni/node-density-cni.yml
@@ -14,8 +14,8 @@ jobs:
     jobIterations: {{.JOB_ITERATIONS}}
     qps: {{.QPS}}
     burst: {{.BURST}}
-    namespacedIterations: true
-    iterationsPerNamespace: 1000
+    namespacedIterations: {{.NAMESPACED_ITERATIONS}}
+    iterationsPerNamespace: {{.ITERATIONS_PER_NAMESPACE}}
     podWait: false
     waitWhenFinished: true
     preLoadImages: true

--- a/cmd/kube-burner/ocp-config/node-density-heavy/node-density-heavy.yml
+++ b/cmd/kube-burner/ocp-config/node-density-heavy/node-density-heavy.yml
@@ -18,8 +18,8 @@ jobs:
     jobIterations: {{.JOB_ITERATIONS}}
     qps: {{.QPS}}
     burst: {{.BURST}}
-    namespacedIterations: true
-    iterationsPerNamespace: 1000
+    namespacedIterations: {{.NAMESPACED_ITERATIONS}}
+    iterationsPerNamespace: {{.ITERATIONS_PER_NAMESPACE}}
     podWait: false
     waitWhenFinished: true
     preLoadImages: true

--- a/pkg/workloads/node-density-cni.go
+++ b/pkg/workloads/node-density-cni.go
@@ -26,6 +26,8 @@ import (
 // NewNodeDensity holds node-density-cni workload
 func NewNodeDensityCNI(wh *WorkloadHelper) *cobra.Command {
 	var podsPerNode int
+	var namespacedIterations bool
+	var iterationsPerNamespace int
 	cmd := &cobra.Command{
 		Use:          "node-density-cni",
 		Short:        "Runs node-density-cni workload",
@@ -38,11 +40,15 @@ func NewNodeDensityCNI(wh *WorkloadHelper) *cobra.Command {
 				log.Fatal(err)
 			}
 			os.Setenv("JOB_ITERATIONS", fmt.Sprint((totalPods-podCount)/2))
+			os.Setenv("NAMESPACED_ITERATIONS", fmt.Sprint(namespacedIterations))
+			os.Setenv("ITERATIONS_PER_NAMESPACE", fmt.Sprint(iterationsPerNamespace))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			wh.run(cmd.Name(), MetricsProfileMap[cmd.Name()])
 		},
 	}
 	cmd.Flags().IntVar(&podsPerNode, "pods-per-node", 245, "Pods per node")
+	cmd.Flags().BoolVar(&namespacedIterations, "namespaced-iterations", true, "Namespaced iterations")
+	cmd.Flags().IntVar(&iterationsPerNamespace, "iterations-per-namespace", 1000, "Iterations per namespace")
 	return cmd
 }

--- a/pkg/workloads/node-density-heavy.go
+++ b/pkg/workloads/node-density-heavy.go
@@ -28,6 +28,8 @@ import (
 func NewNodeDensityHeavy(wh *WorkloadHelper) *cobra.Command {
 	var podsPerNode int
 	var podReadyThreshold, probesPeriod time.Duration
+	var namespacedIterations bool
+	var iterationsPerNamespace int
 	cmd := &cobra.Command{
 		Use:          "node-density-heavy",
 		Short:        "Runs node-density-heavy workload",
@@ -43,6 +45,8 @@ func NewNodeDensityHeavy(wh *WorkloadHelper) *cobra.Command {
 			os.Setenv("JOB_ITERATIONS", fmt.Sprint((totalPods-podCount)/2))
 			os.Setenv("POD_READY_THRESHOLD", fmt.Sprintf("%v", podReadyThreshold))
 			os.Setenv("PROBES_PERIOD", fmt.Sprint(probesPeriod.Seconds()))
+			os.Setenv("NAMESPACED_ITERATIONS", fmt.Sprint(namespacedIterations))
+			os.Setenv("ITERATIONS_PER_NAMESPACE", fmt.Sprint(iterationsPerNamespace))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			wh.run(cmd.Name(), MetricsProfileMap[cmd.Name()])
@@ -51,5 +55,7 @@ func NewNodeDensityHeavy(wh *WorkloadHelper) *cobra.Command {
 	cmd.Flags().DurationVar(&podReadyThreshold, "pod-ready-threshold", 1*time.Hour, "Pod ready timeout threshold")
 	cmd.Flags().DurationVar(&probesPeriod, "probes-period", 10*time.Second, "Perf app readiness/livenes probes period")
 	cmd.Flags().IntVar(&podsPerNode, "pods-per-node", 245, "Pods per node")
+	cmd.Flags().BoolVar(&namespacedIterations, "namespaced-iterations", true, "Namespaced iterations")
+	cmd.Flags().IntVar(&iterationsPerNamespace, "iterations-per-namespace", 1000, "Iterations per namespace")
 	return cmd
 }


### PR DESCRIPTION
This commit adds namespaced-iterations and iterations-per-namespace
cli options to configure namespacedIterations and iterationsPerNamespace
respectively for node-density-cni and node-density-heavy workloads