### PR TITLE
add user-metadata on import and each datapoint

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -182,6 +182,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				}
 			}
 			prometheusClient.JobList = prometheusJobList
+			prometheusClient.Metadata = metadata
 			// If prometheus is enabled query metrics from the start of the first job to the end of the last one
 			if globalConfig.IndexerConfig.Type != "" {
 				metrics.ScrapeMetrics(prometheusClient, indexer)

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -38,7 +38,7 @@ func NewPrometheusClient(configSpec config.Spec, url string, auth Auth, step tim
 		UUID:       configSpec.GlobalConfig.UUID,
 		ConfigSpec: configSpec,
 		Endpoint:   url,
-		metadata:   metadata,
+		Metadata:   metadata,
 	}
 	log.Infof("👽 Initializing prometheus client with URL: %s", url)
 	p.Client, err = prometheus.NewClient(url, auth.Token, auth.Username, auth.Password, auth.SkipTLSVerify)
@@ -95,7 +95,7 @@ func (p *Prometheus) ScrapeJobsMetrics(indexer *indexers.Indexer) error {
 					MetricName:  md.MetricName,
 					JobConfig:   p.findJob(end),
 					Timestamp:   end,
-					Metadata:    p.metadata,
+					Metadata:    p.Metadata,
 					Aggregation: agg,
 					Value:       result,
 				}
@@ -205,7 +205,7 @@ func (p *Prometheus) createMetric(query, metricName string, labels model.Metric,
 		MetricName: metricName,
 		JobConfig:  jobConfig,
 		Timestamp:  timestamp,
-		Metadata:   p.metadata,
+		Metadata:   p.Metadata,
 	}
 	for k, v := range labels {
 		if k != "__name__" {

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -37,7 +37,7 @@ type Prometheus struct {
 	UUID          string
 	ConfigSpec    config.Spec
 	JobList       []Job
-	metadata      map[string]interface{}
+	Metadata      map[string]interface{}
 }
 
 type Job struct {

--- a/pkg/util/metrics/tarball.go
+++ b/pkg/util/metrics/tarball.go
@@ -95,8 +95,14 @@ func ImportTarball(tarball string, indexer *indexers.Indexer, metricsDir string,
 		}
 		log.Infof("Importing metrics from %s", hdr.Name)
 		for _, document := range metrics {
-			log.Infof("Appending metadata %s", userMetadata)
-			document["metadata"] = userMetadata
+			if len(userMetadata) > 0 {
+				previousMetadata, _ := json.Marshal(document["metadata"])
+				if len(document["metadata"].(map[string]any)) > 0 {
+					log.Infof("Existing metadata %s", previousMetadata)
+					log.Infof("Replacing with metadata %s", userMetadata)
+				}
+				document["metadata"] = userMetadata
+			}
 			log.Infof("Writing metric to: %s", metricsDir)
 			_, err = (*indexer).Index([]interface{}{document}, indexers.IndexingOpts{})
 			if err != nil {

--- a/pkg/util/userMetadata.go
+++ b/pkg/util/userMetadata.go
@@ -16,5 +16,6 @@ func ReadUserMetadata(inputFile string) (map[string]interface{}, error) {
 	}
 	yamlDec := yaml.NewDecoder(f)
 	err = yamlDec.Decode(&userMetadata)
+	log.Infof("Loaded user metadata: %s", userMetadata)
 	return userMetadata, err
 }


### PR DESCRIPTION
* insert user-metadata on import
* insert user-metadata for each indexed document/metric

import (inserting metadata):
```
$ cat metadata.yaml 
num_nodes: 9
node_type: c2d-highcpu-8
num_deployments: 1
num_pods: 1
num_namespaces: 10
run_id: 1688140609
$ kube-burner import --config=cluster-density-template.yml --tarball node-9--c2d-highcpu-8--dep-1--pod-1--workload-10--run-168814060.tar.gz --user-metadata ./metadata.yaml 
time="2023-06-30 10:10:10" level=info msg="📁 Creating indexer: elastic" file="kube-burner.go:253"
time="2023-06-30 10:10:12" level=info msg="Reading provided user metadata from ./metadata.yaml" file="userMetadata.go:11"
time="2023-06-30 10:10:12" level=info msg="Importing tarball node-9--c2d-highcpu-8--dep-1--pod-1--workload-10--run-168814060.tar.gz" file="tarball.go:72"
...
```