### PR TITLE
Using only one deamonset to fetch all the preload images

### DIFF
--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -100,48 +100,54 @@ func createDSs(imageList []string, namespaceLabels map[string]string) error {
 	if err := createNamespace(preLoadNs, nsLabels); err != nil {
 		log.Fatal(err)
 	}
-	for i, image := range imageList {
-		dsName := fmt.Sprintf("preload-%d", i)
-		container := corev1.Container{
-			Name:            "kube-burner-rocks",
-			ImagePullPolicy: corev1.PullAlways,
-			Image:           image,
-		}
-		ds := appsv1.DaemonSet{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "DaemonSet",
-				APIVersion: "apps/v1",
+	dsName := "preload"
+	ds := appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: dsName,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": dsName},
 			},
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: dsName,
-			},
-			Spec: appsv1.DaemonSetSpec{
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"app": dsName},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": dsName},
 				},
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{"app": dsName},
-					},
-					Spec: corev1.PodSpec{
-						TerminationGracePeriodSeconds: pointer.Int64(0),
-						InitContainers:                []corev1.Container{container},
-						// Only Always restart policy is supported
-						Containers: []corev1.Container{
-							{
-								Name:  "sleep",
-								Image: "gcr.io/google_containers/pause-amd64:3.0",
-							},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: pointer.Int64(0),
+					InitContainers:                []corev1.Container{},
+					// Only Always restart policy is supported
+					Containers: []corev1.Container{
+						{
+							Name:            "sleep",
+							Image:           "gcr.io/google_containers/pause-amd64:3.0",
+							ImagePullPolicy: corev1.PullAlways,
 						},
 					},
 				},
 			},
+		},
+	}
+
+	// Add the list of containers using images
+	for i, image := range imageList {
+		container := corev1.Container{
+			Name:            fmt.Sprintf("container-%d", i),
+			ImagePullPolicy: corev1.PullAlways,
+			Image:           image,
+			Command:         []string{"echo", fmt.Sprintf("init container-%d completed", i)},
 		}
-		log.Infof("Pre-load: Creating DaemonSet using image %s in namespace %s", image, preLoadNs)
-		_, err := ClientSet.AppsV1().DaemonSets(preLoadNs).Create(context.TODO(), &ds, metav1.CreateOptions{})
-		if err != nil {
-			return err
-		}
+		ds.Spec.Template.Spec.InitContainers = append(ds.Spec.Template.Spec.InitContainers, container)
+	}
+
+	log.Infof("Pre-load: Creating DaemonSet using images %v in namespace %s", imageList, preLoadNs)
+	_, err := ClientSet.AppsV1().DaemonSets(preLoadNs).Create(context.TODO(), &ds, metav1.CreateOptions{})
+	if err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Currently kube-burner does deploy a demonset for each image in the preload step which will create `pods=number_of_worker_nodes` for each image. This approach uses only one single deamonset for the entire list of images as we only care about pulling them into our cluster rather then running them in the `preload` step.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested on my self managed cluster by verifying the events. Attaching the logs below.
```
^C[vchalla@vchalla ~]$ oc get events
LAST SEEN   TYPE      REASON             OBJECT                   MESSAGE
14s         Normal    Scheduled          pod/preload2jpmt-hwcqc   Successfully assigned preload-kube-burner/preload2jpmt-hwcqc to ip-10-0-192-233.us-west-2.compute.internal
14s         Normal    AddedInterface     pod/preload2jpmt-hwcqc   Add eth0 [10.128.2.132/23] from ovn-kubernetes
10s         Normal    Pulling            pod/preload2jpmt-hwcqc   Pulling image "registry.redhat.io/rhel8/postgresql-10@sha256:4b912c80085b88a03309aeb7907efcc29dd3342fa3952b6ea067afb1914bfe53"
13s         Normal    Pulled             pod/preload2jpmt-hwcqc   Successfully pulled image "registry.redhat.io/rhel8/postgresql-10@sha256:4b912c80085b88a03309aeb7907efcc29dd3342fa3952b6ea067afb1914bfe53" in 1.254680227s (1.254692137s including waiting)
9s          Normal    Created            pod/preload2jpmt-hwcqc   Created container container-0
9s          Normal    Started            pod/preload2jpmt-hwcqc   Started container container-0
12s         Normal    Pulling            pod/preload2jpmt-hwcqc   Pulling image "quay.io/cloud-bulldozer/perfapp:latest"
11s         Normal    Pulled             pod/preload2jpmt-hwcqc   Successfully pulled image "quay.io/cloud-bulldozer/perfapp:latest" in 1.193207898s (1.193223358s including waiting)
11s         Normal    Created            pod/preload2jpmt-hwcqc   Created container container-1
11s         Normal    Started            pod/preload2jpmt-hwcqc   Started container container-1
```
