### PR TITLE
Adding node selector labels for preload step

### DIFF
--- a/cmd/kube-burner/ocp-config/cluster-density-v2/build.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density-v2/build.yml
@@ -4,6 +4,10 @@ apiVersion: build.openshift.io/v1
 metadata:
   name: {{.JobName}}-{{.Replica}}
 spec:
+  resources:
+    requests:
+      cpu: 10m
+      memory: "10Mi"
   nodeSelector:
     node-role.kubernetes.io/worker: ""
   serviceAccount: builder

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -60,11 +60,14 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | `errorOnVerify`        | Set RC to 1 when objects verification fails                                      | Boolean | true    |
 | `preLoadImages`        | Kube-burner will create a DS before triggering the job to pull all the images of the job   | true    |
 | `preLoadPeriod`        | How long to wait for the preload daemonset                                       | Duration| 1m     |
+| `preloadNodeLabels`    | Add node selector labels for the resources created in preload stage              | Object  | {} |
 | `namespaceLabels`      | Add custom labels to the namespaces created by kube-burner                       | Object  | {} |
 | `churn`                | Churn the workload. Only supports namespace based workloads                      | Boolean | false |
 | `churnPercent`         | Percentage of the jobIterations to churn each period                             | Integer | 10 |
 | `churnDuration`        | Length of time that the job is churned for                                       | Duration| 1h |
 | `churnDelay`           | Length of time to wait between each churn period                                 | Duration| 5m |
+
+Our configuration files strictly follow YAML syntax. To clarify on List and Object types usage, they are nothing but the `Lists and Dictionaries` in YAML syntax like mentioned [here](https://gettaurus.org/docs/YAMLTutorial/#Lists-and-Dictionaries). Please feel free to refer YAML syntax more for details on a specific `Type` usage. 
 
 Examples of valid configuration files can be found at the [examples folder](https://github.com/cloud-bulldozer/kube-burner/tree/master/examples).
 

--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -47,7 +47,7 @@ func preLoadImages(job Executor) error {
 	if err != nil {
 		return fmt.Errorf("pre-load: %v", err)
 	}
-	err = createDSs(imageList, job.NamespaceLabels)
+	err = createDSs(imageList, job.NamespaceLabels, job.PreLoadNodeLabels)
 	if err != nil {
 		return fmt.Errorf("pre-load: %v", err)
 	}
@@ -90,7 +90,7 @@ func getJobImages(job Executor) ([]string, error) {
 	return imageList, nil
 }
 
-func createDSs(imageList []string, namespaceLabels map[string]string) error {
+func createDSs(imageList []string, namespaceLabels map[string]string, nodeSelectorLabels map[string]string) error {
 	nsLabels := map[string]string{
 		"kube-burner-preload": "true",
 	}
@@ -128,6 +128,7 @@ func createDSs(imageList []string, namespaceLabels map[string]string) error {
 							ImagePullPolicy: corev1.PullAlways,
 						},
 					},
+					NodeSelector: nodeSelectorLabels,
 				},
 			},
 		},

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -135,6 +135,8 @@ type Job struct {
 	PreLoadImages bool `yaml:"preLoadImages" json:"preLoadImages,omitempty"`
 	// PreLoadPeriod determines the duration of the preload stage
 	PreLoadPeriod time.Duration `yaml:"preLoadPeriod" json:"preLoadPeriod,omitempty"`
+	// PreLoadNodeLabels add node selector labels to resources in preload stage
+	PreLoadNodeLabels map[string]string `yaml:"preLoadNodeLabels" json:"-"`
 	// NamespaceLabels add custom labels to namespaces created by kube-burner
 	NamespaceLabels map[string]string `yaml:"namespaceLabels" json:"-"`
 	// Churn workload


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Added a parameter to specify node selectors in the preload step. This provides us with the flexibility to fully run kube-burner in desired set of nodes.

## Related Tickets & Documents

- Related Issue #
- Closes # https://github.com/cloud-bulldozer/kube-burner/issues/288

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested building a binary on my self managed cluster.
### Step: 1
Added labels `app=test` to one of worker nodes.
```
ip-10-0-183-53.us-west-2.compute.internal    Ready    worker                 82d   v1.25.8+27e744f   app=test,beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=m5.4xlarge,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=us-west-2,failure-domain.beta.kubernetes.io/zone=us-west-2b,kubernetes.io/arch=amd64,kubernetes.io/hostname=ip-10-0-183-53.us-west-2.compute.internal,kubernetes.io/os=linux,node-role.kubernetes.io/worker=,node.kubernetes.io/instance-type=m5.4xlarge,node.openshift.io/os_id=rhcos,topology.ebs.csi.aws.com/zone=us-west-2b,topology.kubernetes.io/region=us-west-2,topology.kubernetes.io/zone=us-west-2b 
```
### Step: 2
Modified the node-density-heavy config `jobs` section to use the label.
```
jobs:
  - name: node-density-heavy
    namespace: node-density-heavy
    jobIterations: {{.JOB_ITERATIONS}}
    qps: {{.QPS}}
    burst: {{.BURST}}
    namespacedIterations: true
    iterationsPerNamespace: 1000
    podWait: false
    waitWhenFinished: true
    preLoadImages: true
    preLoadPeriod: 15s
    preLoadNodeLabels:
      app: test
    namespaceLabels:
      security.openshift.io/scc.podSecurityLabelSync: false
      pod-security.kubernetes.io/enforce: privileged
      pod-security.kubernetes.io/audit: privileged
      pod-security.kubernetes.io/warn: privileged
    objects:

      - objectTemplate: postgres-deployment.yml
        replicas: 1
```
### Step: 3
Ran and verified if the pre-load pods are getting deployed only in the nodes that has specified labels.
```
NAME                   READY   STATUS                  RESTARTS     AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
preload-0wsp7m-64bdb   0/1     Init:CrashLoopBackOff   1 (7s ago)   12s   10.129.3.71   ip-10-0-183-53.us-west-2.compute.internal   <none>           <none>
preload-1czp49-f7m6z   0/1     Init:0/1                0            11s   10.129.3.72   ip-10-0-183-53.us-west-2.compute.internal   <none>           <none>
```