### PR TITLE
Cluster-Density-v2: Create services and router before client pods

### DIFF
--- a/cmd/kube-burner/ocp-config/cluster-density-v2/cluster-density-v2.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density-v2/cluster-density-v2.yml
@@ -30,16 +30,22 @@ jobs:
       pod-security.kubernetes.io/warn: privileged
     objects:
 
-      - objectTemplate: imagestream.yml
-        replicas: 1
+      - objectTemplate: service.yml
+        replicas: 5
 
-      - objectTemplate: build.yml
-        replicas: 1
+      - objectTemplate: route.yml
+        replicas: 2
 
       - objectTemplate: deployment-server.yml
         replicas: 3
         inputVars:
           podReplicas: 2
+
+      - objectTemplate: imagestream.yml
+        replicas: 1
+
+      - objectTemplate: build.yml
+        replicas: 1
 
       - objectTemplate: deployment-client.yml
         replicas: 2


### PR DESCRIPTION
This is required because the readiness probe of the client depends on being able to hit the service/route. It only makes sense to create the service and route before the client pod.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [X] Optimization
- [ ] Documentation Update
