### PR TITLE
Removing waitWhenFinished global flag by default in node density heavy

### DIFF
--- a/cmd/kube-burner/ocp-config/node-density-heavy/node-density-heavy.yml
+++ b/cmd/kube-burner/ocp-config/node-density-heavy/node-density-heavy.yml
@@ -1,7 +1,6 @@
 ---
 global:
   gc: {{.GC}}
-  waitWhenFinished: true
   indexerConfig:
     esServers: ["{{.ES_SERVER}}"]
     insecureSkipVerify: true


### PR DESCRIPTION
Removing waitWhenFinished global flag by default in node density heavy  config.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Removing `waitWhenFinished` by default in node-density-heavy that was set in this [PR](https://github.com/cloud-bulldozer/kube-burner/pull/378).

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
