### PR TITLE
Remove config File flag from index subcommand

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -166,7 +166,7 @@ func destroyCmd() *cobra.Command {
 		},
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			listOptions := v1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-uuid=%s", uuid)}
+			listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-uuid=%s", uuid)}
 			clientSet, restConfig, err := config.GetClientSet(0, 0)
 			if err != nil {
 				log.Fatalf("Error creating clientSet: %s", err)

--- a/pkg/alerting/alert_manager.go
+++ b/pkg/alerting/alert_manager.go
@@ -202,7 +202,6 @@ func parseMatrix(value model.Value, description string, severity severityLevel) 
 
 func (a *AlertManager) index(alertSet []interface{}) {
 	log.Info("Indexing alerts")
-	log.Infof("Indexing alert %s", alertMetricName)
 	log.Debugf("Indexing [%d] documents", len(alertSet))
 	resp, err := (*a.indexer).Index(alertSet, indexers.IndexingOpts{MetricName: alertMetricName})
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -129,6 +129,9 @@ func Parse(uuid, c string) (Spec, error) {
 	if len(configSpec.Jobs) <= 0 {
 		return configSpec, fmt.Errorf("No jobs found in the configuration file")
 	}
+	if err := jobIsDuped(); err != nil {
+		return configSpec, err
+	}
 	if err := validateDNS1123(); err != nil {
 		return configSpec, err
 	}
@@ -225,4 +228,15 @@ func buildConfig(kubeconfigPath string) (*rest.Config, error) {
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
 		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: ""}}).ClientConfig()
+}
+
+func jobIsDuped() error {
+	jobCount := make(map[string]int)
+	for _, job := range configSpec.Jobs {
+		jobCount[job.Name]++
+		if jobCount[job.Name] > 1 {
+			return fmt.Errorf("Job names must be unique")
+		}
+	}
+	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -104,7 +104,7 @@ func (j *Job) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // Parse parses a configuration file
-func Parse(uuid, c string, jobsRequired bool) (Spec, error) {
+func Parse(uuid, c string) (Spec, error) {
 	f, err := util.ReadConfig(c)
 	if err != nil {
 		return configSpec, fmt.Errorf("Error reading configuration file %s: %s", c, err)
@@ -126,24 +126,22 @@ func Parse(uuid, c string, jobsRequired bool) (Spec, error) {
 	if err = yamlDec.Decode(&configSpec); err != nil {
 		return configSpec, fmt.Errorf("Error decoding configuration file %s: %s", c, err)
 	}
-	if jobsRequired {
-		if len(configSpec.Jobs) <= 0 {
-			return configSpec, fmt.Errorf("No jobs found in the configuration file")
+	if len(configSpec.Jobs) <= 0 {
+		return configSpec, fmt.Errorf("No jobs found in the configuration file")
+	}
+	if err := validateDNS1123(); err != nil {
+		return configSpec, err
+	}
+	for _, job := range configSpec.Jobs {
+		if len(job.Namespace) > 62 {
+			log.Warnf("Namespace %s length has > 62 characters, truncating it", job.Namespace)
+			job.Namespace = job.Namespace[:57]
 		}
-		if err := validateDNS1123(); err != nil {
-			return configSpec, err
+		if !job.NamespacedIterations && job.Churn {
+			log.Fatal("Cannot have Churn enabled without Namespaced Iterations also enabled")
 		}
-		for _, job := range configSpec.Jobs {
-			if len(job.Namespace) > 62 {
-				log.Warnf("Namespace %s length has > 62 characters, truncating it", job.Namespace)
-				job.Namespace = job.Namespace[:57]
-			}
-			if !job.NamespacedIterations && job.Churn {
-				log.Fatal("Cannot have Churn enabled without Namespaced Iterations also enabled")
-			}
-			if job.JobIterations < 1 && job.JobType == CreationJob {
-				log.Fatalf("Job %s has < 1 iterations", job.Name)
-			}
+		if job.JobIterations < 1 && job.JobType == CreationJob {
+			log.Fatalf("Job %s has < 1 iterations", job.Name)
 		}
 	}
 	configSpec.GlobalConfig.UUID = uuid

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -230,54 +230,54 @@ func (p *podLatency) normalizeMetrics() {
 		m.ContainersReadyLatency = int(m.containersReady.Sub(m.Timestamp).Milliseconds())
 		m.ContainersReadyLatencyV2 = int(m.containersReady.Sub(m.CreationTimestampV2).Milliseconds())
 		if m.ContainersReadyLatency < 0 {
-			log.Tracef("ContainersReadyLatency for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			log.Tracef("ContainersReadyLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.ContainersReadyLatency = 0
 		}
 		if m.ContainersReadyLatencyV2 < 0 {
-			log.Tracef("ContainersReadyLatencyV2 for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			log.Tracef("ContainersReadyLatencyV2 for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.ContainersReadyLatencyV2 = 0
 		}
-		log.Tracef("ContainersReadyLatency: %+v for pod %+v", m.ContainersReadyLatency, m.Name)
-		log.Tracef("ContainersReadyLatencyV2: %+v for pod %+v", m.ContainersReadyLatencyV2, m.Name)
+		log.Tracef("ContainersReadyLatency: %v for pod %v", m.ContainersReadyLatency, m.Name)
+		log.Tracef("ContainersReadyLatencyV2: %v for pod %v", m.ContainersReadyLatencyV2, m.Name)
 
 		m.SchedulingLatency = int(m.scheduled.Sub(m.Timestamp).Milliseconds())
 		m.SchedulingLatencyV2 = int(m.scheduled.Sub(m.CreationTimestampV2).Milliseconds())
 		if m.SchedulingLatency < 0 {
-			log.Tracef("SchedulingLatency for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			log.Tracef("SchedulingLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.SchedulingLatency = 0
 		}
 		if m.SchedulingLatencyV2 < 0 {
-			log.Tracef("SchedulingLatencyV2 for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			log.Tracef("SchedulingLatencyV2 for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.SchedulingLatencyV2 = 0
 		}
-		log.Tracef("SchedulingLatency: %+v for pod %+v", m.SchedulingLatency, m.Name)
-		log.Tracef("SchedulingLatencyV2: %+v for pod %+v", m.SchedulingLatencyV2, m.Name)
+		log.Tracef("SchedulingLatency: %v for pod %v", m.SchedulingLatency, m.Name)
+		log.Tracef("SchedulingLatencyV2: %v for pod %v", m.SchedulingLatencyV2, m.Name)
 
 		m.InitializedLatency = int(m.initialized.Sub(m.Timestamp).Milliseconds())
 		m.InitializedLatencyV2 = int(m.initialized.Sub(m.CreationTimestampV2).Milliseconds())
 		if m.InitializedLatency < 0 {
-			log.Tracef("InitializedLatency for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			log.Tracef("InitializedLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.InitializedLatency = 0
 		}
 		if m.InitializedLatencyV2 < 0 {
-			log.Tracef("InitializedLatencyV2 for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			log.Tracef("InitializedLatencyV2 for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.InitializedLatencyV2 = 0
 		}
-		log.Tracef("InitializedLatency: %+v for pod %+v", m.InitializedLatency, m.Name)
-		log.Tracef("InitializedLatencyV2: %+v for pod %+v", m.InitializedLatencyV2, m.Name)
+		log.Tracef("InitializedLatency: %v for pod %v", m.InitializedLatency, m.Name)
+		log.Tracef("InitializedLatencyV2: %v for pod %v", m.InitializedLatencyV2, m.Name)
 
 		m.PodReadyLatency = int(m.podReady.Sub(m.Timestamp).Milliseconds())
 		m.PodReadyLatencyV2 = int(m.podReady.Sub(m.CreationTimestampV2).Milliseconds())
 		if m.PodReadyLatency < 0 {
-			log.Tracef("PodReadyLatency for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			log.Tracef("PodReadyLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.PodReadyLatency = 0
 		}
 		if m.PodReadyLatencyV2 < 0 {
-			log.Tracef("PodReadyLatencyV2 for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			log.Tracef("PodReadyLatencyV2 for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.PodReadyLatencyV2 = 0
 		}
-		log.Tracef("PodReadyLatency: %+v for pod %+v", m.PodReadyLatency, m.Name)
-		log.Tracef("PodReadyLatencyV2: %+v for pod %+v", m.PodReadyLatencyV2, m.Name)
+		log.Tracef("PodReadyLatency: %v for pod %v", m.PodReadyLatency, m.Name)
+		log.Tracef("PodReadyLatencyV2: %v for pod %v", m.PodReadyLatencyV2, m.Name)
 		p.normLatencies = append(p.normLatencies, m)
 	}
 }

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -179,7 +179,7 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 	} else {
 		log.Infof("File %v available in the current directory, using it", cfg)
 	}
-	configSpec, err = config.Parse(wh.Metadata.UUID, cfg, true)
+	configSpec, err = config.Parse(wh.Metadata.UUID, cfg)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/k8s/kube-burner-index-single-endpoint.yml
+++ b/test/k8s/kube-burner-index-single-endpoint.yml
@@ -1,6 +1,0 @@
-global:
-  indexerConfig:
-    esServers: [https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443] 
-    insecureSkipVerify: true
-    defaultIndex: ripsaw-kube-burner
-    type: elastic

--- a/test/test-k8s.bats
+++ b/test/test-k8s.bats
@@ -64,14 +64,12 @@ teardown_file() {
 }
 
 @test "kube-burner index: metrics-endpoint with single prometheus endpoint" {
-  export INDEXING_TYPE=local
-  run kube-burner index -c kube-burner-index-single-endpoint.yml --uuid="${UUID}"  -u http://localhost:9090 -m metrics-profile.yaml
+  run kube-burner index --uuid="${UUID}"  -u http://localhost:9090 -m metrics-profile.yaml
   [ "$status" -eq 0 ]
 }
 
-@test "kube-burner index: metrics-endpoint" {
-  export INDEXING_TYPE=local
-  run kube-burner index -c kube-burner.yml --uuid="${UUID}" -e metrics-endpoints.yaml
+@test "kube-burner index: metrics-endpoint and sending metrics to ES" {
+  run kube-burner index --uuid="${UUID}" -e metrics-endpoints.yaml --es-server=https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443 --es-index=ripsaw-kube-burner
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Config file is not required anymore to run `kube-burner index`

## Related Tickets & Documents

- Related Issue #
- Closes #384

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
