### PR TITLE
Fix patch job to wait for resources to be ready

### DIFF
--- a/pkg/burner/patch.go
+++ b/pkg/burner/patch.go
@@ -191,10 +191,7 @@ func (ex *Executor) patchHandler(obj object, originalItem unstructured.Unstructu
 		log.Debugf("Patched %s/%s in namespace %s", uns.GetKind(), uns.GetName(), ns)
 	}
 
-	// We need to give Kubernetes a little time to actually apply the patch and make changes before we can wait on it
-	// If we aren't waiting for the job to finish, we can just carry on
 	if ex.WaitWhenFinished {
-		time.Sleep(50 * time.Millisecond)
 		ex.waitForObjects(ns)
 	}
 

--- a/pkg/burner/waiters.go
+++ b/pkg/burner/waiters.go
@@ -85,7 +85,8 @@ func waitForDeployments(ns string, maxWaitTimeout time.Duration, wg *sync.WaitGr
 			return false, err
 		}
 		for _, dep := range deps.Items {
-			if *dep.Spec.Replicas != dep.Status.ReadyReplicas {
+			// We need to wait for Updated & Ready replicas (they're slightly different) to ensure the deployment is ready
+			if *dep.Spec.Replicas != dep.Status.UpdatedReplicas || *dep.Spec.Replicas != dep.Status.ReadyReplicas {
 				log.Debugf("Waiting for replicas from deployments in ns %s to be ready", ns)
 				return false, nil
 			}


### PR DESCRIPTION

## Type of change

- [ ] Refactor
- [] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Fix patch jobs such that they can wait for resources for finish completing before continuing
   This is important for testing Deployment objects since they take a while to process and they have a lot of downstream effects.
- Fix race condition on access metric list 
   Occurs at v. high throughput and will crash kube-burner
- Run all resources in patch jobs together, then wait (optional), then do the next iteration
   This will kick off all the dissimilar workloads at the same time, allowing for more and heavier load on disparate parts of the api-server

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] If it is a core feature, I have added thorough tests.
