### PR TITLE
Fixing measurement for pod lantencies

### DIFF
--- a/docs/measurements.md
+++ b/docs/measurements.md
@@ -76,6 +76,9 @@ Where `quantileName` matches with the pod conditions and can be:
 - `ContainersReady`: Indicates whether all containers in the pod are ready.
 - `Ready`: The pod is able to service requests and should be added to the load balancing pools of all matching services.
 
+!!! note
+    There are a V2 version of these latencies as well. Both are being kept with the intention of monitoring them over time (i.e precision vs accuracy problem) Therefore, if you notice a significant discrepancy and want to tell us about it, please feel free to do so. Or else prefer to stay with the non-v2 and everything will continue to be the same as it always has been.
+
 !!! info
     More information about the pod conditions can be found at the [kubernetes documentation site](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions).
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -31,7 +31,7 @@ In this section is described global job configuration, it holds the following pa
 | `waitWhenFinished` | Wait for all pods to be running when all jobs are completed                                             | Boolean        | false      |
 
 !!! note 
-    The precedence order to wait on resources is Global.waitWhenFinished > Jod.waitWhenFinished > Job.podWait
+    The precedence order to wait on resources is Global.waitWhenFinished > Job.waitWhenFinished > Job.podWait
 
 kube-burner connects k8s clusters using the following methods in this order:
 

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -93,8 +93,9 @@ func setupCreateJob(jobConfig config.Job) Executor {
 // RunCreateJob executes a creation job
 func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNamespaces *[]string) {
 	nsLabels := map[string]string{
-		"kube-burner-job":  ex.Name,
-		"kube-burner-uuid": ex.uuid,
+		"kube-burner-job":   ex.Name,
+		"kube-burner-uuid":  ex.uuid,
+		"kube-burner-runid": ex.runid,
 	}
 	var wg sync.WaitGroup
 	var ns string
@@ -198,6 +199,7 @@ func (ex *Executor) replicaHandler(objectIndex int, obj object, ns string, itera
 				"kube-burner-uuid":  ex.uuid,
 				"kube-burner-job":   ex.Name,
 				"kube-burner-index": strconv.Itoa(objectIndex),
+				"kube-burner-runid": ex.runid,
 			}
 			templateData := map[string]interface{}{
 				jobName:      ex.Name,
@@ -219,6 +221,7 @@ func (ex *Executor) replicaHandler(objectIndex int, obj object, ns string, itera
 				labels[k] = v
 			}
 			newObject.SetLabels(labels)
+			setMetadataLabels(newObject, labels)
 			json.Marshal(newObject.Object)
 			// replicaWg is necessary because we want to wait for all replicas
 			// to be created before running any other action such as verify objects,

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -55,6 +55,7 @@ type Executor struct {
 	End     time.Time
 	config.Job
 	uuid    string
+	runid   string
 	limiter *rate.Limiter
 }
 
@@ -267,6 +268,7 @@ func newExecutorList(configSpec config.Spec, uuid string, timeout time.Duration)
 		ex.limiter = rate.NewLimiter(rate.Limit(job.QPS), job.Burst)
 		ex.Job = job
 		ex.uuid = uuid
+		ex.runid = configSpec.GlobalConfig.RUNID
 		executorList = append(executorList, ex)
 	}
 	return executorList

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cloud-bulldozer/kube-burner/pkg/util"
 	log "github.com/sirupsen/logrus"
 
+	uid "github.com/satori/go.uuid"
 	"gopkg.in/yaml.v3"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -40,6 +41,7 @@ import (
 
 var configSpec = Spec{
 	GlobalConfig: GlobalConfig{
+		RUNID:          uid.NewV4().String(),
 		GC:             false,
 		GCTimeout:      1 * time.Hour,
 		RequestTimeout: 15 * time.Second,

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -45,6 +45,8 @@ type Spec struct {
 type GlobalConfig struct {
 	// Benchmark UUID
 	UUID string
+	// Benchmark RUNID
+	RUNID string
 	// IndexerConfig contains a IndexerConfig definition
 	IndexerConfig indexers.IndexerConfig `yaml:"indexerConfig"`
 	// Measurements describes a list of measurements kube-burner

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -79,7 +79,8 @@ func (p *podLatency) handleCreatePod(obj interface{}) {
 	pod := obj.(*v1.Pod)
 	jobConfig := *factory.jobConfig
 	if _, exists := p.metrics[string(pod.UID)]; !exists {
-		if strings.Contains(pod.Namespace, factory.jobConfig.Namespace) {
+		runid, exists := pod.Labels["kube-burner-runid"]
+		if exists && runid == globalCfg.RUNID {
 			p.metrics[string(pod.UID)] = podMetric{
 				Timestamp:           now,
 				CreationTimestampV2: pod.CreationTimestamp.Time.UTC(),
@@ -226,6 +227,10 @@ func (p *podLatency) normalizeMetrics() {
 			log.Tracef("ContainersReadyLatency for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.ContainersReadyLatency = 0
 		}
+		if m.ContainersReadyLatencyV2 < 0 {
+			log.Tracef("ContainersReadyLatencyV2 for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			m.ContainersReadyLatencyV2 = 0
+		}
 		log.Tracef("ContainersReadyLatency: %+v for pod %+v", m.ContainersReadyLatency, m.Name)
 		log.Tracef("ContainersReadyLatencyV2: %+v for pod %+v", m.ContainersReadyLatencyV2, m.Name)
 
@@ -234,6 +239,10 @@ func (p *podLatency) normalizeMetrics() {
 		if m.SchedulingLatency < 0 {
 			log.Tracef("SchedulingLatency for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.SchedulingLatency = 0
+		}
+		if m.SchedulingLatencyV2 < 0 {
+			log.Tracef("SchedulingLatencyV2 for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			m.SchedulingLatencyV2 = 0
 		}
 		log.Tracef("SchedulingLatency: %+v for pod %+v", m.SchedulingLatency, m.Name)
 		log.Tracef("SchedulingLatencyV2: %+v for pod %+v", m.SchedulingLatencyV2, m.Name)
@@ -244,6 +253,10 @@ func (p *podLatency) normalizeMetrics() {
 			log.Tracef("InitializedLatency for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.InitializedLatency = 0
 		}
+		if m.InitializedLatencyV2 < 0 {
+			log.Tracef("InitializedLatencyV2 for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			m.InitializedLatencyV2 = 0
+		}
 		log.Tracef("InitializedLatency: %+v for pod %+v", m.InitializedLatency, m.Name)
 		log.Tracef("InitializedLatencyV2: %+v for pod %+v", m.InitializedLatencyV2, m.Name)
 
@@ -252,6 +265,10 @@ func (p *podLatency) normalizeMetrics() {
 		if m.PodReadyLatency < 0 {
 			log.Tracef("PodReadyLatency for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
 			m.PodReadyLatency = 0
+		}
+		if m.PodReadyLatencyV2 < 0 {
+			log.Tracef("PodReadyLatencyV2 for pod %+v falling under negative case. So explicitly setting it to 0", m.Name)
+			m.PodReadyLatencyV2 = 0
 		}
 		log.Tracef("PodReadyLatency: %+v for pod %+v", m.PodReadyLatency, m.Name)
 		log.Tracef("PodReadyLatencyV2: %+v for pod %+v", m.PodReadyLatencyV2, m.Name)


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Modifying logic to uniquely identify the run specific resources, ignoring the rest while calculating latencies. And also handling negative cases for v2 latencies to be on safe side, which ideally shouldn't happen in most of the cases.

## Related Tickets & Documents

- Related Issue # https://github.com/cloud-bulldozer/kube-burner/issues/413
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested on self-managed AWS cluster and made sure the resources are not being repeated in latency calculations.

Initial run: https://gist.github.com/vishnuchalla/17d969f94d4cd1c909e29b6438837265
Follow up run: https://gist.github.com/vishnuchalla/da565a4de189f7c8edd6bb4a65ddc4fa
