### PR TITLE
Fix the missing versioning information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GIT_COMMIT = $(shell git rev-parse HEAD)
 VERSION ?= $(shell hack/tag_name.sh)
 SOURCES := $(shell find . -type f -name "*.go")
 BUILD_DATE = $(shell date '+%Y-%m-%d-%H:%M:%S')
-KUBE_BURNER_VERSION= github.com/cloud-bulldozer/kube-burner/pkg/version
+KUBE_BURNER_VERSION= github.com/cloud-bulldozer/go-commons/version
 
 # Containers
 ENGINE ?= podman


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR fixes the missing versioning information

```
# ../kube-burner/bin/amd64/kube-burner version
Version: fix_me
Git Commit: 6e42248f1a20fc6e3670df8db904a8fe0d2d226a
Build Date: 2023-08-14-16:48:30
Go Version: go1.20.1
OS/Arch: darwin amd64
# ../kube-burner/bin/amd64/kube-burner help
Kube-burner 🔥

Tool aimed at stressing a kubernetes cluster by creating or deleting lots of objects.

Usage:
  kube-burner [command]

Available Commands:
  check-alerts Evaluate alerts for the given time range
  completion   Generates completion scripts for bash shell
  destroy      Destroy old namespaces labeled with the given UUID.
  help         Help about any command
  import       Import metrics tarball
  index        Index kube-burner metrics
  init         Launch benchmark
  ocp          OpenShift wrapper
  version      Print the version number of kube-burner

Flags:
  -h, --help               help for kube-burner
      --log-level string   Allowed values: debug, info, warn, error, fatal (default "info")

Use "kube-burner [command] --help" for more information about a command.
 # 
```

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #430 
- Closes #430 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
