### PR TITLE
Cleanup and code optimizations

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -240,13 +240,14 @@ func newExecutorList(configSpec config.Spec, uuid string, timeout time.Duration)
 	}
 	discoveryClient = discovery.NewDiscoveryClientForConfigOrDie(restConfig)
 	for _, job := range configSpec.Jobs {
-		if job.JobType == config.CreationJob {
+		switch job.JobType {
+		case config.CreationJob:
 			ex = setupCreateJob(job)
-		} else if job.JobType == config.DeletionJob {
+		case config.DeletionJob:
 			ex = setupDeleteJob(&job)
-		} else if job.JobType == config.PatchJob {
+		case config.PatchJob:
 			ex = setupPatchJob(job)
-		} else {
+		default:
 			log.Fatalf("Unknown jobType: %s", job.JobType)
 		}
 		for _, j := range executorList {

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -80,7 +80,6 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 	var err error
 	var rc int
 	var prometheusJobList []prometheus.Job
-	var measurementStopFunctions []func() error
 	var jobList []Executor
 	res := make(chan int, 1)
 	uuid := configSpec.GlobalConfig.UUID
@@ -122,7 +121,8 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 					ctx, cancel := context.WithTimeout(context.Background(), globalConfig.GCTimeout)
 					defer cancel()
 					CleanupNamespaces(ctx, v1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-job=%s", job.Name)}, true)
-					CleanupNonNamespacedResources(ctx, v1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-job=%s", job.Name)}, true)
+					CleanupNonNamespacedResourcesUsingGVR(ctx, jobList, true)
+
 				}
 				if job.Churn {
 					log.Info("Churning enabled")
@@ -174,22 +174,13 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 					log.Errorf("Failed measurements: %v", err.Error())
 					innerRC = 1
 				}
-			} else {
-				measurementStopFunctions = append(measurementStopFunctions, measurements.Stop)
 			}
 		}
 		if globalConfig.WaitWhenFinished {
 			runWaitList(globalWaitMap, executorMap)
-			endTime := time.Now().UTC()
-			for jobIndex, stopFunc := range measurementStopFunctions {
-				jobList[jobIndex].End = endTime
-				if len(prometheusJobList) > jobIndex {
-					prometheusJobList[jobIndex].End = endTime
-				}
-				if err := stopFunc(); err != nil {
-					log.Errorf("Failed measurements: %v", err.Error())
-					innerRC = 1
-				}
+			if err = measurements.Stop(); err != nil {
+				log.Errorf("Failed measurements: %v", err.Error())
+				innerRC = 1
 			}
 		}
 		if globalConfig.IndexerConfig.Type != "" {
@@ -234,7 +225,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 		defer cancel()
 		log.Info("Garbage collecting remaining namespaces")
 		CleanupNamespaces(ctx, v1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-uuid=%v", uuid)}, true)
-		CleanupNonNamespacedResourcesUsingGvr(ctx, jobList, true)
+		CleanupNonNamespacedResourcesUsingGVR(ctx, jobList, true)
 	}
 	return rc, nil
 }

--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -106,7 +106,7 @@ func CleanupNonNamespacedResources(ctx context.Context, l metav1.ListOptions, cl
 }
 
 // Cleanup non-namespaced resources using executor list
-func CleanupNonNamespacedResourcesUsingGvr(ctx context.Context, executorList []Executor, cleanupWait bool) {
+func CleanupNonNamespacedResourcesUsingGVR(ctx context.Context, executorList []Executor, cleanupWait bool) {
 	log.Info("Deleting non-namespace resources specific to this benchmark")
 	for _, executor := range executorList {
 		for _, object := range executor.objects {

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
+	"github.com/cloud-bulldozer/kube-burner/pkg/config"
 	"github.com/cloud-bulldozer/kube-burner/pkg/measurements/metrics"
 	"github.com/cloud-bulldozer/kube-burner/pkg/measurements/types"
 	log "github.com/sirupsen/logrus"
@@ -71,12 +72,14 @@ type vmiMetric struct {
 	vmReady        time.Time
 	VMReadyLatency int `json:"vmReadyLatency"`
 
-	MetricName string `json:"metricName"`
-	JobName    string `json:"jobName"`
-	UUID       string `json:"uuid"`
-	Namespace  string `json:"namespace"`
-	Name       string `json:"podName"`
-	NodeName   string `json:"nodeName"`
+	MetricName string      `json:"metricName"`
+	JobName    string      `json:"jobName"`
+	JobConfig  config.Job  `json:"jobConfig"`
+	Metadata   interface{} `json:"metadata,omitempty"`
+	UUID       string      `json:"uuid"`
+	Namespace  string      `json:"namespace"`
+	Name       string      `json:"podName"`
+	NodeName   string      `json:"nodeName"`
 }
 
 type vmiLatency struct {
@@ -107,6 +110,8 @@ func (p *vmiLatency) handleCreateVM(obj interface{}) {
 				MetricName: vmiLatencyMeasurement,
 				UUID:       globalCfg.UUID,
 				JobName:    factory.jobConfig.Name,
+				JobConfig:  *factory.jobConfig,
+				Metadata:   factory.metadata,
 			}
 		}
 	}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

- Remove the `measurementStopFunctions` variable.
- Call `CleanupNonNamespacedResourcesUsingGVR` during cleanup stage rather than `CleanupNonNamespacedResources`
- Add locks to pod latency calculations, multi-job benchmarks are failing due a potential concurrent map access by the different goroutines
- Missing fields to VMI & VM latency calculation

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
