### PR TITLE
Improve error handling and messaging

### DIFF
--- a/docs/ocp.md
+++ b/docs/ocp.md
@@ -188,6 +188,7 @@ type ClusterMetadata struct {
   SDNType          string `json:"sdnType"`
   ClusterName      string `json:"clusterName"`
   Region           string `json:"region"`
+  ExecutionErrors  string `json:"executionErrors"`
 }
 ```
 

--- a/pkg/alerting/alert_manager.go
+++ b/pkg/alerting/alert_manager.go
@@ -28,13 +28,12 @@ import (
 	"github.com/prometheus/common/model"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 type severityLevel string
 
 const (
-	Passed                        = 0
-	Failed                        = 1
 	sevWarn         severityLevel = "warning"
 	sevError        severityLevel = "error"
 	sevCritical     severityLevel = "critical"
@@ -100,18 +99,18 @@ func (a *AlertManager) readProfile(alertProfileCfg string) error {
 	yamlDec := yaml.NewDecoder(f)
 	yamlDec.KnownFields(true)
 	if err = yamlDec.Decode(&a.alertProfile); err != nil {
-		return fmt.Errorf("Error decoding alert profile %s: %s", alertProfileCfg, err)
+		return fmt.Errorf("error decoding alert profile %s: %s", alertProfileCfg, err)
 	}
 	return a.validateTemplates()
 }
 
 // Evaluate evaluates expressions
-func (a *AlertManager) Evaluate(start, end time.Time) int {
+func (a *AlertManager) Evaluate(start, end time.Time) error {
+	errs := []error{}
 	log.Infof("Evaluating alerts for prometheus: %v", a.prometheus.Endpoint)
 	var alertList []interface{}
 	elapsed := int(end.Sub(start).Minutes())
 	var renderedQuery bytes.Buffer
-	result := Passed
 	vars := util.EnvToMap()
 	vars["elapsed"] = fmt.Sprintf("%dm", elapsed)
 	for _, alert := range a.alertProfile {
@@ -119,28 +118,26 @@ func (a *AlertManager) Evaluate(start, end time.Time) int {
 		t.Execute(&renderedQuery, vars)
 		expr := renderedQuery.String()
 		renderedQuery.Reset()
-		log.Infof("Evaluating expression: '%s'", expr)
+		log.Debugf("Evaluating expression: '%s'", expr)
 		v, err := a.prometheus.Client.QueryRange(expr, start, end, a.prometheus.Step)
 		if err != nil {
 			log.Warnf("Error performing query %s: %s", expr, err)
 			continue
 		}
-		alarmResult, alertData, err := parseMatrix(v, alert.Description, alert.Severity)
+		alertData, err := parseMatrix(v, alert.Description, alert.Severity)
 		if err != nil {
-			log.Error(err)
+			log.Error(err.Error())
+			errs = append(errs, err)
 		}
 		for _, alertSet := range alertData {
 			alertSet.UUID = a.uuid
 			alertList = append(alertList, alertSet)
 		}
-		if alarmResult == Failed {
-			result = Failed
-		}
 	}
 	if len(alertList) > 0 && a.indexer != nil {
 		a.index(alertList)
 	}
-	return result
+	return utilerrors.NewAggregate(errs)
 }
 
 func (a *AlertManager) validateTemplates() error {
@@ -152,16 +149,16 @@ func (a *AlertManager) validateTemplates() error {
 	return nil
 }
 
-func parseMatrix(value model.Value, description string, severity severityLevel) (int, []alert, error) {
+func parseMatrix(value model.Value, description string, severity severityLevel) ([]alert, error) {
 	var renderedDesc bytes.Buffer
 	var templateData descriptionTemplate
 	// The same query can fire multiple alerts, so we have to return an array of them
 	var alertSet []alert
-	result := Passed
+	errs := []error{}
 	t, _ := template.New("").Parse(strings.Join(append(baseTemplate, description), ""))
 	data, ok := value.(model.Matrix)
 	if !ok {
-		return result, alertSet, fmt.Errorf("unsupported result format: %s", value.Type().String())
+		return alertSet, fmt.Errorf("unsupported result format: %s", value.Type().String())
 	}
 	for _, v := range data {
 		templateData.Labels = make(map[string]string)
@@ -173,10 +170,11 @@ func parseMatrix(value model.Value, description string, severity severityLevel) 
 			// Take 3 decimals
 			templateData.Value = math.Round(float64(val.Value)*1000) / 1000
 			if err := t.Execute(&renderedDesc, templateData); err != nil {
-				log.Errorf("Rendering error: %s", err)
-				result = Failed
+				msg := fmt.Errorf("alert rendering error: %s", err)
+				log.Error(msg.Error())
+				errs = append(errs, err)
 			}
-			msg := fmt.Sprintf("🚨 Alert at %v: '%s'", val.Timestamp.Time().Format(time.RFC3339), renderedDesc.String())
+			msg := fmt.Sprintf("alert at %v: '%s'", val.Timestamp.Time().Format(time.RFC3339), renderedDesc.String())
 			alertSet = append(alertSet, alert{
 				Timestamp:   val.Timestamp.Time(),
 				Severity:    string(severity),
@@ -185,19 +183,18 @@ func parseMatrix(value model.Value, description string, severity severityLevel) 
 			})
 			switch severity {
 			case sevWarn:
-				log.Warn(msg)
+				log.Warnf("🚨 %s", msg)
 			case sevError:
-				result = Failed
-				log.Error(msg)
+				errs = append(errs, fmt.Errorf(msg))
 			case sevCritical:
-				log.Fatal(msg)
+				log.Fatalf("🚨 %s", msg)
 			default:
-				log.Info(msg)
+				log.Infof("🚨 %s", msg)
 			}
 			break
 		}
 	}
-	return result, alertSet, nil
+	return alertSet, utilerrors.NewAggregate(errs)
 }
 
 func (a *AlertManager) index(alertSet []interface{}) {

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -16,6 +16,7 @@ package burner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -30,9 +31,9 @@ import (
 	"github.com/cloud-bulldozer/kube-burner/pkg/util/metrics"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -81,6 +82,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 	var rc int
 	var prometheusJobList []prometheus.Job
 	var jobList []Executor
+	errs := []error{}
 	res := make(chan int, 1)
 	uuid := configSpec.GlobalConfig.UUID
 	globalConfig := configSpec.GlobalConfig
@@ -120,9 +122,8 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				if job.Cleanup {
 					ctx, cancel := context.WithTimeout(context.Background(), globalConfig.GCTimeout)
 					defer cancel()
-					CleanupNamespaces(ctx, v1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-job=%s", job.Name)}, true)
+					CleanupNamespaces(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-job=%s", job.Name)}, true)
 					CleanupNonNamespacedResourcesUsingGVR(ctx, jobList, true)
-
 				}
 				if job.Churn {
 					log.Info("Churning enabled")
@@ -133,13 +134,13 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				job.RunCreateJob(0, job.JobIterations, &waitListNamespaces)
 				// If object verification is enabled
 				if job.VerifyObjects && !job.Verify() {
-					errMsg := "Object verification failed"
-					// If errorOnVerify is enabled. Set RC to 1
+					err := errors.New("object verification failed")
+					// If errorOnVerify is enabled. Set RC to 1 and append error
 					if job.ErrorOnVerify {
-						errMsg += ". Setting return code to 1"
 						innerRC = 1
+						errs = append(errs, err)
 					}
-					log.Error(errMsg)
+					log.Error(err.Error())
 				}
 				if job.Churn {
 					job.RunCreateJobWithChurn()
@@ -171,7 +172,8 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				elapsedTime := jobList[jobPosition].End.Sub(jobList[jobPosition].Start).Round(time.Second)
 				log.Infof("Job %s took %v", job.Name, elapsedTime)
 				if err = measurements.Stop(); err != nil {
-					log.Errorf("Failed measurements: %v", err.Error())
+					errs = append(errs, err)
+					log.Error(err.Error())
 					innerRC = 1
 				}
 			}
@@ -179,7 +181,8 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 		if globalConfig.WaitWhenFinished {
 			runWaitList(globalWaitMap, executorMap)
 			if err = measurements.Stop(); err != nil {
-				log.Errorf("Failed measurements: %v", err.Error())
+				errs = append(errs, err)
+				log.Error(err.Error())
 				innerRC = 1
 			}
 		}
@@ -192,12 +195,13 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 		}
 		// We initialize cleanup as soon as the benchmark finishes
 		if globalConfig.GC {
-			go CleanupNamespaces(context.TODO(), v1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-uuid=%v", uuid)}, false)
+			go CleanupNamespaces(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-uuid=%v", uuid)}, false)
 		}
 		for idx, prometheusClient := range prometheusClients {
 			// If alertManager is configured
 			if alertMs[idx] != nil {
-				if alertMs[idx].Evaluate(jobList[0].Start, jobList[len(jobList)-1].End) == 1 {
+				if err := alertMs[idx].Evaluate(jobList[0].Start, jobList[len(jobList)-1].End); err != nil {
+					errs = append(errs, err)
 					innerRC = 1
 				}
 			}
@@ -216,7 +220,9 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 	select {
 	case rc = <-res:
 	case <-time.After(timeout):
-		log.Errorf("%v timeout reached", timeout)
+		err := fmt.Errorf("%v timeout reached", timeout)
+		log.Errorf(err.Error())
+		errs = append(errs, err)
 		rc = rcTimeout
 	}
 	if globalConfig.GC {
@@ -224,10 +230,10 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 		ctx, cancel := context.WithTimeout(context.Background(), globalConfig.GCTimeout)
 		defer cancel()
 		log.Info("Garbage collecting remaining namespaces")
-		CleanupNamespaces(ctx, v1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-uuid=%v", uuid)}, true)
+		CleanupNamespaces(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-uuid=%v", uuid)}, true)
 		CleanupNonNamespacedResourcesUsingGVR(ctx, jobList, true)
 	}
-	return rc, nil
+	return rc, utilerrors.NewAggregate(errs)
 }
 
 // newExecutorList Returns a list of executors

--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -16,6 +16,7 @@ package burner
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -23,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -112,9 +112,7 @@ func CleanupNonNamespacedResourcesUsingGVR(ctx context.Context, executorList []E
 		for _, object := range executor.objects {
 			if !object.Namespaced {
 				resourceInterface := DynamicClient.Resource(object.gvr)
-				listOptions := metav1.ListOptions{
-					LabelSelector: labels.SelectorFromSet(object.labelSelector).String(),
-				}
+				listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("kube-burner-job=%s", executor.Name)}
 				resources, err := resourceInterface.List(ctx, listOptions)
 				if err != nil {
 					log.Debugf("Unable to list resources for object: %v error: %v. Hence skipping it", object.Object, err)

--- a/pkg/measurements/metrics/watcher.go
+++ b/pkg/measurements/metrics/watcher.go
@@ -31,6 +31,7 @@ type Watcher struct {
 	Informer    cache.SharedInformer
 }
 
+// NewWatcher return a new ListWatcher of the specified resource and namespace
 func NewWatcher(restClient *rest.RESTClient, name string, resource string, namespace string) *Watcher {
 	lw := cache.NewFilteredListWatchFromClient(
 		restClient,

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloud-bulldozer/kube-burner/pkg/measurements/metrics"
 	"github.com/cloud-bulldozer/kube-burner/pkg/measurements/types"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -77,7 +78,7 @@ func init() {
 
 func (p *podLatency) handleCreatePod(obj interface{}) {
 	now := time.Now().UTC()
-	pod := obj.(*v1.Pod)
+	pod := obj.(*corev1.Pod)
 	p.metricLock.Lock()
 	defer p.metricLock.Unlock()
 	if _, exists := p.metrics[string(pod.UID)]; !exists {
@@ -104,22 +105,22 @@ func (p *podLatency) handleUpdatePod(obj interface{}) {
 	defer p.metricLock.Unlock()
 	if pm, exists := p.metrics[string(pod.UID)]; exists && pm.podReady.IsZero() {
 		for _, c := range pod.Status.Conditions {
-			if c.Status == v1.ConditionTrue {
+			if c.Status == corev1.ConditionTrue {
 				switch c.Type {
-				case v1.PodScheduled:
+				case corev1.PodScheduled:
 					if pm.scheduled.IsZero() {
 						pm.scheduled = c.LastTransitionTime.Time.UTC()
 						pm.NodeName = pod.Spec.NodeName
 					}
-				case v1.PodInitialized:
+				case corev1.PodInitialized:
 					if pm.initialized.IsZero() {
 						pm.initialized = c.LastTransitionTime.Time.UTC()
 					}
-				case v1.ContainersReady:
+				case corev1.ContainersReady:
 					if pm.containersReady.IsZero() {
 						pm.containersReady = c.LastTransitionTime.Time.UTC()
 					}
-				case v1.PodReady:
+				case corev1.PodReady:
 					if pm.podReady.IsZero() {
 						log.Debugf("Pod %s is ready", pod.Name)
 						pm.podReady = c.LastTransitionTime.Time.UTC()
@@ -148,7 +149,7 @@ func (p *podLatency) start(measurementWg *sync.WaitGroup) {
 		factory.clientSet.CoreV1().RESTClient().(*rest.RESTClient),
 		"podWatcher",
 		"pods",
-		v1.NamespaceAll,
+		corev1.NamespaceAll,
 	)
 	p.watcher.Informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: p.handleCreatePod,
@@ -162,13 +163,13 @@ func (p *podLatency) start(measurementWg *sync.WaitGroup) {
 }
 
 // Stop stops podLatency measurement
-func (p *podLatency) stop() (int, error) {
-	var rc int
+func (p *podLatency) stop() error {
+	var err error
 	p.watcher.StopWatcher()
 	p.normalizeMetrics()
 	p.calcQuantiles()
 	if len(p.config.LatencyThresholds) > 0 {
-		rc = metrics.CheckThreshold(p.config.LatencyThresholds, p.latencyQuantiles)
+		err = metrics.CheckThreshold(p.config.LatencyThresholds, p.latencyQuantiles)
 	}
 	if globalCfg.IndexerConfig.Type != "" {
 		log.Infof("Indexing pod latency data for job: %s", factory.jobConfig.Name)
@@ -182,7 +183,7 @@ func (p *podLatency) stop() (int, error) {
 	}
 	// Reset latency slices, required in multi-job benchmarks
 	p.latencyQuantiles, p.normLatencies = nil, nil
-	return rc, nil
+	return err
 }
 
 // index sends metrics to the configured indexer
@@ -284,17 +285,17 @@ func (p *podLatency) normalizeMetrics() {
 
 func (p *podLatency) calcQuantiles() {
 	quantiles := []float64{0.5, 0.95, 0.99}
-	quantileMap := map[v1.PodConditionType][]int{}
+	quantileMap := map[corev1.PodConditionType][]int{}
 	jc := factory.jobConfig
 	jc.Objects = nil
 	for _, normLatency := range p.normLatencies {
-		quantileMap[v1.PodScheduled] = append(quantileMap[v1.PodScheduled], normLatency.(podMetric).SchedulingLatency)
+		quantileMap[corev1.PodScheduled] = append(quantileMap[corev1.PodScheduled], normLatency.(podMetric).SchedulingLatency)
 		quantileMap["PodScheduledV2"] = append(quantileMap["PodScheduledV2"], normLatency.(podMetric).SchedulingLatencyV2)
-		quantileMap[v1.ContainersReady] = append(quantileMap[v1.ContainersReady], normLatency.(podMetric).ContainersReadyLatency)
+		quantileMap[corev1.ContainersReady] = append(quantileMap[corev1.ContainersReady], normLatency.(podMetric).ContainersReadyLatency)
 		quantileMap["ContainersReadyV2"] = append(quantileMap["ContainersReadyV2"], normLatency.(podMetric).ContainersReadyLatencyV2)
-		quantileMap[v1.PodInitialized] = append(quantileMap[v1.PodInitialized], normLatency.(podMetric).InitializedLatency)
+		quantileMap[corev1.PodInitialized] = append(quantileMap[corev1.PodInitialized], normLatency.(podMetric).InitializedLatency)
 		quantileMap["InitializedV2"] = append(quantileMap["InitializedV2"], normLatency.(podMetric).InitializedLatencyV2)
-		quantileMap[v1.PodReady] = append(quantileMap[v1.PodReady], normLatency.(podMetric).PodReadyLatency)
+		quantileMap[corev1.PodReady] = append(quantileMap[corev1.PodReady], normLatency.(podMetric).PodReadyLatency)
 		quantileMap["ReadyV2"] = append(quantileMap["ReadyV2"], normLatency.(podMetric).PodReadyLatencyV2)
 	}
 	for quantileName, v := range quantileMap {
@@ -329,7 +330,7 @@ func (p *podLatency) validateConfig() error {
 	var metricFound bool
 	var latencyMetrics = []string{"P99", "P95", "P50", "Avg", "Max"}
 	for _, th := range p.config.LatencyThresholds {
-		if th.ConditionType == string(v1.ContainersReady) || th.ConditionType == string(v1.PodInitialized) || th.ConditionType == string(v1.PodReady) || th.ConditionType == string(v1.PodScheduled) {
+		if th.ConditionType == string(corev1.ContainersReady) || th.ConditionType == string(corev1.PodInitialized) || th.ConditionType == string(corev1.PodReady) || th.ConditionType == string(corev1.PodScheduled) {
 			for _, lm := range latencyMetrics {
 				if th.Metric == lm {
 					metricFound = true

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cloud-bulldozer/kube-burner/pkg/measurements/types"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubectl/pkg/scheme"
 
@@ -83,7 +83,7 @@ func (p *pprof) start(measurementWg *sync.WaitGroup) {
 
 func getPods(target types.PProftarget) []corev1.Pod {
 	labelSelector := labels.Set(target.LabelSelector).String()
-	podList, err := factory.clientSet.CoreV1().Pods(target.Namespace).List(context.TODO(), v1.ListOptions{LabelSelector: labelSelector})
+	podList, err := factory.clientSet.CoreV1().Pods(target.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		log.Errorf("Error found listing pods labeled with %s: %s", labelSelector, err)
 	}
@@ -179,9 +179,9 @@ func (p *pprof) getPProf(wg *sync.WaitGroup, first bool) {
 	wg.Wait()
 }
 
-func (p *pprof) stop() (int, error) {
+func (p *pprof) stop() error {
 	p.stopChannel <- true
-	return 0, nil
+	return nil
 }
 
 func readCerts(cert, privKey string) (string, string, error) {

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -51,6 +51,7 @@ type BenchmarkMetadata struct {
 	Timestamp    time.Time              `json:"timestamp"`
 	EndDate      time.Time              `json:"endDate"`
 	Passed       bool                   `json:"passed"`
+	Errors       string                 `json:"errors"`
 	UserMetadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
@@ -233,7 +234,8 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 	}
 	rc, err = burner.Run(configSpec, prometheusClients, alertMs, indexer, wh.timeout, metadata)
 	if err != nil {
-		log.Fatal(err)
+		wh.Metadata.Errors = err.Error()
+		log.Error(err)
 	}
 	wh.Metadata.Passed = rc == 0
 	if indexerConfig.Type != "" {

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -46,13 +46,13 @@ const (
 
 type BenchmarkMetadata struct {
 	ocpmetadata.ClusterMetadata
-	UUID         string                 `json:"uuid"`
-	Benchmark    string                 `json:"benchmark"`
-	Timestamp    time.Time              `json:"timestamp"`
-	EndDate      time.Time              `json:"endDate"`
-	Passed       bool                   `json:"passed"`
-	Errors       string                 `json:"errors"`
-	UserMetadata map[string]interface{} `json:"metadata,omitempty"`
+	UUID            string                 `json:"uuid"`
+	Benchmark       string                 `json:"benchmark"`
+	Timestamp       time.Time              `json:"timestamp"`
+	EndDate         time.Time              `json:"endDate"`
+	Passed          bool                   `json:"passed"`
+	ExecutionErrors string                 `json:"executionErrors"`
+	UserMetadata    map[string]interface{} `json:"metadata,omitempty"`
 }
 
 type WorkloadHelper struct {
@@ -234,7 +234,7 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 	}
 	rc, err = burner.Run(configSpec, prometheusClients, alertMs, indexer, wh.timeout, metadata)
 	if err != nil {
-		wh.Metadata.Errors = err.Error()
+		wh.Metadata.ExecutionErrors = err.Error()
 		log.Error(err)
 	}
 	wh.Metadata.Passed = rc == 0


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Improving error handling. The Run() function now returns an exception (error) on these conditions:

- Benchmark timeout
- Measurement failure, returned from measurements Stop() methods
- Object count verification error

This new logic simplifies the error logic making it more efficient and easy to read.
---

In addition, all the errors are concatenated in a single string. That string is added to a new "errors" field of the `clusterMetadata` document as follows:

```shell
$ ./bin/amd64/kube-burner ocp node-density --pods-per-node=65 --pod-ready-threshold=1s  --local-indexing                                                                                   
time="2023-08-17 12:22:58" level=info msg="File node-density.yml available in the current directory, using it" file="helpers.go:181"                                                                                                          
time="2023-08-17 12:22:58" level=info msg="📁 Creating indexer: local" file="helpers.go:189"                                                                                                                                                  
time="2023-08-17 12:22:58" level=info msg="👽 Initializing prometheus client with URL: https://prometheus-k8s-openshift-monitoring.apps.cloud-bulldozer-ci.perfscale.devcluster.openshift.com" file="prometheus.go:43"                        
time="2023-08-17 12:22:59" level=info msg="🔔 Initializing alert manager for prometheus: https://prometheus-k8s-openshift-monitoring.apps.cloud-bulldozer-ci.perfscale.devcluster.openshift.com" file="alert_manager.go:82"                   
time="2023-08-17 12:22:59" level=info msg="🔥 Starting kube-burner (issue-438@e4bdfa9b3894e995f64bf074914834997e4dce5a) with UUID dc29c53d-28c5-488f-9a87-e05dbb0ed076" file="job.go:92"                                                      
time="2023-08-17 12:22:59" level=info msg="📈 Creating measurement factory" file="factory.go:53"                                                                                                                                              
time="2023-08-17 12:22:59" level=info msg="Registered measurement: podLatency" file="factory.go:85"                                                                                                                                           
time="2023-08-17 12:23:00" level=info msg="Job node-density: 25 iterations with 1 Pod replicas" file="create.go:87"                                                                                                                           
time="2023-08-17 12:23:00" level=info msg="QPS: 20" file="job.go:103"                                  
time="2023-08-17 12:23:00" level=info msg="Burst: 20" file="job.go:104"                                                                                                                                                                       
time="2023-08-17 12:23:00" level=info msg="Triggering job: node-density" file="job.go:119"                             
time="2023-08-17 12:23:00" level=info msg="Creating Pod latency watcher for node-density" file="pod_latency.go:142"                                                                                                                           
I0817 12:23:03.350294  310946 request.go:696] Waited for 1.049893644s due to client-side throttling, not priority and fairness, request: GET:https://api.cloud-bulldozer-ci.perfscale.devcluster.openshift.com:6443/apis/logging.openshift.io/
v1?timeout=15s                                                                                                                                                                                                                                
time="2023-08-17 12:23:05" level=info msg="Deleting non-namespace resources with label kube-burner-job=node-density" file="namespaces.go:84"                                                                                                  
W0817 12:23:05.640262  310946 warnings.go:70] v1 ComponentStatus is deprecated in v1.19+                                                                                                                                                      
time="2023-08-17 12:23:28" level=info msg="Running job node-density" file="create.go:103"                                                                                                                                                     
time="2023-08-17 12:23:28" level=info msg="2/25 iterations completed" file="create.go:121"                                                                                                                                                    
time="2023-08-17 12:23:28" level=info msg="4/25 iterations completed" file="create.go:121"                                                                                                                                                    
time="2023-08-17 12:23:28" level=info msg="6/25 iterations completed" file="create.go:121"                                                                                                                                                    
time="2023-08-17 12:23:28" level=info msg="8/25 iterations completed" file="create.go:121"                             
time="2023-08-17 12:23:28" level=info msg="10/25 iterations completed" file="create.go:121"                                                                                                                                                   
time="2023-08-17 12:23:28" level=info msg="12/25 iterations completed" file="create.go:121"                            
time="2023-08-17 12:23:28" level=info msg="14/25 iterations completed" file="create.go:121"                                                                                                                                                   
time="2023-08-17 12:23:28" level=info msg="16/25 iterations completed" file="create.go:121"                            
time="2023-08-17 12:23:28" level=info msg="18/25 iterations completed" file="create.go:121"                                                                                                                                                   
time="2023-08-17 12:23:28" level=info msg="20/25 iterations completed" file="create.go:121"                            
time="2023-08-17 12:23:28" level=info msg="22/25 iterations completed" file="create.go:121"                                                                                                                                                   
time="2023-08-17 12:23:29" level=info msg="24/25 iterations completed" file="create.go:121"                            
time="2023-08-17 12:23:29" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:155"                                                                                                                             
time="2023-08-17 12:23:33" level=info msg="Actions in namespace node-density completed" file="waiters.go:76"           
time="2023-08-17 12:23:33" level=info msg="Verifying created objects" file="utils.go:86"                                                                                                                                                      
time="2023-08-17 12:23:33" level=info msg="pods found: 25 Expected: 25" file="utils.go:119"                            
time="2023-08-17 12:23:33" level=info msg="Job node-density took 34s" file="job.go:174"                                                                                                                                                       time="2023-08-17 12:23:33" level=info msg="Stopping measurement: podLatency" file="factory.go:109"                     
time="2023-08-17 12:23:33" level=info msg="Evaluating latency thresholds" file="metrics.go:60"                                                                                                                                                
time="2023-08-17 12:23:33" level=info msg="Indexing pod latency data for job: node-density" file="pod_latency.go:170"                                                                                                                         
time="2023-08-17 12:23:33" level=info msg="File collected-metrics/podLatencyMeasurement-node-density.json created with 25 documents" file="pod_latency.go:202"                                                                                
time="2023-08-17 12:23:33" level=info msg="File collected-metrics/podLatencyQuantilesMeasurement-node-density.json created with 8 documents" file="pod_latency.go:202"                                                                        
time="2023-08-17 12:23:33" level=info msg="node-density: Initialized 50th: 0 99th: 0 max: 0 avg: 0" file="pod_latency.go:176"                                                                                                                 
time="2023-08-17 12:23:33" level=info msg="node-density: Ready 50th: 1959 99th: 2725 max: 2725 avg: 1930" file="pod_latency.go:176"                                                                                                           
time="2023-08-17 12:23:33" level=info msg="node-density: PodScheduled 50th: 0 99th: 0 max: 0 avg: 0" file="pod_latency.go:176"                                                                                                                
time="2023-08-17 12:23:33" level=info msg="node-density: ContainersReady 50th: 1959 99th: 2725 max: 2725 avg: 1930" file="pod_latency.go:176"                                                                                                 
time="2023-08-17 12:23:33" level=error msg="[podLatency: P99 Ready latency (2.72s) higher than configured threshold: 1s, podLatency: P99 ContainersReady latency (2.72s) higher than configured threshold: 1s]" file="job.go:177"             
time="2023-08-17 12:23:33" level=info msg="Indexing metric jobSummary" file="metadata.go:52"                                                                                                                                                  
time="2023-08-17 12:23:33" level=info msg="File collected-metrics/jobSummary-node-density.json created with 1 documents" file="metadata.go:61"                                                                                                
time="2023-08-17 12:23:33" level=info msg="Evaluating alerts for prometheus: https://prometheus-k8s-openshift-monitoring.apps.cloud-bulldozer-ci.perfscale.devcluster.openshift.com" file="alert_manager.go:110"                              
time="2023-08-17 12:23:33" level=info msg="Deleting namespaces with label kube-burner-uuid=dc29c53d-28c5-488f-9a87-e05dbb0ed076" file="namespaces.go:64"                                                                                      
time="2023-08-17 12:23:34" level=error msg="[alert at 2023-08-17T12:23:00+02:00: '10 minutes avg. 99th etcd fsync latency on etcd-ip-10-0-133-30.us-west-2.compute.internal higher than 10ms. 0.01s', alert at 2023-08-17T12:23:00+02:00: '10 
minutes avg. 99th etcd fsync latency on etcd-ip-10-0-173-62.us-west-2.compute.internal higher than 10ms. 0.003s', alert at 2023-08-17T12:23:00+02:00: '10 minutes avg. 99th etcd fsync latency on etcd-ip-10-0-217-162.us-west-2.compute.inter
nal higher than 10ms. 0.005s']" file="alert_manager.go:129"                                                            
time="2023-08-17 12:23:37" level=info msg="Indexing alerts" file="alert_manager.go:201"                                                                                                                                                       
time="2023-08-17 12:23:37" level=info msg="File collected-metrics/alert.json created with 3 documents" file="alert_manager.go:207"                                                                                                            
time="2023-08-17 12:23:37" level=info msg="Scraping https://prometheus-k8s-openshift-monitoring.apps.cloud-bulldozer-ci.perfscale.devcluster.openshift.com Profile: metrics.yml Start: 2023-08-17T10:23:00Z End: 2023-08-17T10:23:33Z" file="u
tils.go:66"             
...
time="2023-08-17 12:23:44" level=info msg="Deleting namespaces with label kube-burner-uuid=dc29c53d-28c5-488f-9a87-e05dbb0ed076" file="namespaces.go:64"
time="2023-08-17 12:23:44" level=info msg="Waiting for namespaces to be definitely deleted" file="namespaces.go:149"
time="2023-08-17 12:23:46" level=info msg="Deleting non-namespace resources specific to this benchmark" file="namespaces.go:110"
time="2023-08-17 12:23:46" level=error msg="[podLatency: P99 Ready latency (2.72s) higher than configured threshold: 1s, podLatency: P99 ContainersReady latency (2.72s) higher than configured threshold: 1s, alert at 2023-08-17T12:23:00+02
:00: '10 minutes avg. 99th etcd fsync latency on etcd-ip-10-0-133-30.us-west-2.compute.internal higher than 10ms. 0.01s', alert at 2023-08-17T12:23:00+02:00: '10 minutes avg. 99th etcd fsync latency on etcd-ip-10-0-173-62.us-west-2.comput
e.internal higher than 10ms. 0.003s', alert at 2023-08-17T12:23:00+02:00: '10 minutes avg. 99th etcd fsync latency on etcd-ip-10-0-217-162.us-west-2.compute.internal higher than 10ms. 0.005s']" file="helpers.go:238"
time="2023-08-17 12:23:46" level=info msg="Indexing cluster metadata document" file="helpers.go:143"
time="2023-08-17 12:23:46" level=info msg="File collected-metrics/clusterMetadata.json created with 1 documents" file="helpers.go:151"
time="2023-08-17 12:23:46" level=info msg="👋 Exiting kube-burner dc29c53d-28c5-488f-9a87-e05dbb0ed076" file="helpers.go:244"
$ echo $?
1                                                                                                           
) $ cat collected-metrics/clusterMetadata.json  | jq .                                                                                                                                       
[                                                                                                                                                                                                                                             
  {                                                                                                                    
    "metricName": "clusterMetadata",                                                                                                                                                                                                          
    "platform": "AWS",                                                                                                 
    "clusterType": "self-managed",                                                                                                                                                                                                            
    "ocpVersion": "4.12.18",                                                                                           
    "ocpMajorVersion": "4.12",                                                                                                                                                                                                                
    "k8sVersion": "v1.25.8+37a9a08",                                                                                   
    "masterNodesType": "m5.2xlarge",                                                                                                                                                                                                          
    "workerNodesType": "",                                                                                             
    "masterNodesCount": 3,                                                                                                                                                                                                                    
    "infraNodesType": "",                                                                                              
    "workerNodesCount": 3,                                                                                                                                                                                                                    
    "infraNodesCount": 0,                                                                                              
    "otherNodesCount": 0,
    "totalNodes": 3,                                                                                                   
    "sdnType": "OpenShiftSDN",                                                                                                                                                                                                                
    "clusterName": "cloud-bulldozer-ci-6hwqr",                                                                                                                                                                                                
    "region": "us-west-2",                                                                                                                                                                                                                    
    "uuid": "dc29c53d-28c5-488f-9a87-e05dbb0ed076",                                                                                                                                                                                           
    "benchmark": "node-density",                                                                                                                                                                                                              
    "timestamp": "2023-08-17T10:22:55.596297514Z",                                                                                                                                                                                            
    "endDate": "2023-08-17T10:23:46.774042843Z",                                                                                                                                                                                              
    "passed": false,                                                                                                   
    "errors": "[podLatency: P99 Ready latency (2.72s) higher than configured threshold: 1s, podLatency: P99 ContainersReady latency (2.72s) higher than configured threshold: 1s, alert at 2023-08-17T12:23:00+02:00: '10 minutes avg. 99th et
cd fsync latency on etcd-ip-10-0-133-30.us-west-2.compute.internal higher than 10ms. 0.01s', alert at 2023-08-17T12:23:00+02:00: '10 minutes avg. 99th etcd fsync latency on etcd-ip-10-0-173-62.us-west-2.compute.internal higher than 10ms. 
0.003s', alert at 2023-08-17T12:23:00+02:00: '10 minutes avg. 99th etcd fsync latency on etcd-ip-10-0-217-162.us-west-2.compute.internal higher than 10ms. 0.005s']"                                                                          
  }                                                                                                                    
] 
```

Also, reducing log level of [_alert manager_ evaluations](https://github.com/cloud-bulldozer/kube-burner/blob/master/pkg/alerting/alert_manager.go#L122) to Debug

## Related Tickets & Documents

- Closes #438

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
