### PR TITLE
Create unique folder for every local indexing job using uuid

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,6 +147,10 @@ func Parse(uuid, c string, jobsRequired bool) (Spec, error) {
 		}
 	}
 	configSpec.GlobalConfig.UUID = uuid
+	if configSpec.GlobalConfig.IndexerConfig.MetricsDirectory == "collected-metrics" {
+		configSpec.GlobalConfig.IndexerConfig.MetricsDirectory += "-" + uuid
+	}
+
 	return configSpec, nil
 }
 

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -35,9 +35,9 @@ teardown_file() {
 }
 
 @test "node-density-heavy with indexing" {
-  run kube-burner ocp node-density-heavy --pods-per-node=75 --local-indexing
+  run kube-burner ocp node-density-heavy --pods-per-node=75 --uuid=abcd --local-indexing
   [ "$status" -eq 0 ]
-  run check_file_list collected-metrics/etcdVersion.json collected-metrics/clusterMetadata.json collected-metrics/jobSummary-node-density-heavy.json collected-metrics/podLatencyMeasurement-node-density-heavy.json collected-metrics/podLatencyQuantilesMeasurement-node-density-heavy.json
+  run check_file_list collected-metrics-abcd/etcdVersion.json collected-metrics-abcd/clusterMetadata.json collected-metrics-abcd/jobSummary-node-density-heavy.json collected-metrics-abcd/podLatencyMeasurement-node-density-heavy.json collected-metrics-abcd/podLatencyQuantilesMeasurement-node-density-heavy.json
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR creates a unique folder appended with the UUID, when used for local indexing. If the 'metricsDirectory' field is not populated, a folder of the type collected-metrics-UUID gets created. This PR addresses issue #402 

## Related Tickets & Documents

- Related Issue #
- Closes #402 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
