### PR TITLE
Adding audit functionality on latencies

### DIFF
--- a/docs/measurements.md
+++ b/docs/measurements.md
@@ -77,7 +77,7 @@ Where `quantileName` matches with the pod conditions and can be:
 - `Ready`: The pod is able to service requests and should be added to the load balancing pools of all matching services.
 
 !!! note
-    We also log the confidence level and the errorRate of the latencies for user's understanding. Currently the threshold for the errorRate is 10% and we do not log latencies if the error is > 10% which indicates a problem with environment.(i.e system under test)
+    We also log the errorRate of the latencies for user's understanding. It indicates the percentage of pods out of all pods in the workload that got errored during the latency calculations. Currently the threshold for the errorRate is 10% and we do not log latencies if the error is > 10% which indicates a problem with environment.(i.e system under test)
 
 !!! info
     More information about the pod conditions can be found at the [kubernetes documentation site](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions).

--- a/docs/measurements.md
+++ b/docs/measurements.md
@@ -77,7 +77,7 @@ Where `quantileName` matches with the pod conditions and can be:
 - `Ready`: The pod is able to service requests and should be added to the load balancing pools of all matching services.
 
 !!! note
-    There are a V2 version of these latencies as well. Both are being kept with the intention of monitoring them over time (i.e precision vs accuracy problem) Therefore, if you notice a significant discrepancy and want to tell us about it, please feel free to do so. Or else prefer to stay with the non-v2 and everything will continue to be the same as it always has been.
+    We also log the confidence level and the errorRate of the latencies for user's understanding. Currently the threshold for the errorRate is 10% and we do not log latencies if the error is > 10% which indicates a problem with environment.(i.e system under test)
 
 !!! info
     More information about the pod conditions can be found at the [kubernetes documentation site](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions).


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

* Finalizing V2 logic for latencies and removing V1.
* Keeping V2 as it is accurate, consistent and supportive for future development practices.
* Adding audit functionality based on V2 as it proved to be reliable. Please take a look at the attached issue for more context. 

## Related Tickets & Documents

- Related Issue # https://github.com/cloud-bulldozer/kube-burner/issues/439
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested on self managed cluster with below command
```
kube-burner ocp node-density-heavy --timeout 1h --metrics-endpoint ~/metrics-endpoints.yaml --pods-per-node=50 --log-level=trace 2>&1 --gc=true | tee -a kube-burner-$(date +"%F_%H-%M-%S")
```
Full logs: https://gist.github.com/vishnuchalla/85f670152ac46ac898779ec301459a1b