### PR TITLE
Add new CRD scale workload

### DIFF
--- a/cmd/kube-burner/ocp-config/crd-scale/crd-scale.yml
+++ b/cmd/kube-burner/ocp-config/crd-scale/crd-scale.yml
@@ -1,0 +1,21 @@
+---
+global:
+  gc: {{.GC}}
+  indexerConfig:
+    esServers: ["{{.ES_SERVER}}"]
+    insecureSkipVerify: true
+    defaultIndex: {{.ES_INDEX}}
+    type: {{.INDEXING_TYPE}}
+jobs:
+  - name: crd-scale
+    namespace: crd-scale
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: false
+    waitWhenFinished: false
+    objects:
+
+      - objectTemplate: example-crd.yml
+        replicas: 1
+

--- a/cmd/kube-burner/ocp-config/crd-scale/example-crd.yml
+++ b/cmd/kube-burner/ocp-config/crd-scale/example-crd.yml
@@ -1,0 +1,29 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kubeburners{{.Iteration}}.cloudbulldozer.example.com
+spec:
+  group: cloudbulldozer.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                workload:
+                  type: string
+                iterations:
+                  type: integer
+  scope: Cluster
+  names:
+    plural: kubeburners{{.Iteration}}
+    singular: kubeburner{{.Iteration}}
+    kind: KubeBurner{{.Iteration}}
+    shortNames:
+    - kb{{.Iteration}}
+

--- a/cmd/kube-burner/ocp.go
+++ b/cmd/kube-burner/ocp.go
@@ -90,6 +90,7 @@ func openShiftCmd() *cobra.Command {
 		workloads.NewClusterDensity(&wh, "cluster-density"),
 		workloads.NewClusterDensity(&wh, "cluster-density-v2"),
 		workloads.NewClusterDensity(&wh, "cluster-density-ms"),
+		workloads.NewCrdScale(&wh),
 		workloads.NewNodeDensity(&wh),
 		workloads.NewNodeDensityHeavy(&wh),
 		workloads.NewNodeDensityCNI(&wh),

--- a/examples/workloads/crd-scale/crd-scale.yml
+++ b/examples/workloads/crd-scale/crd-scale.yml
@@ -1,0 +1,22 @@
+---
+global:
+  gc: true
+  indexerConfig:
+    esServers: [http://elastic-elk.apps.rsevilla.kube-burner.com]
+    insecureSkipVerify: true
+    defaultIndex: kube-burner
+    type: elastic
+
+jobs:
+  - name: crd-scale
+    jobIterations: 1000
+    qps: 20
+    burst: 20
+    namespacedIterations: false
+    namespace: crd-scale
+    waitWhenFinished: false
+    objects:
+
+      - objectTemplate: templates/example-crd.yml
+        replicas: 1
+

--- a/examples/workloads/crd-scale/templates/example-crd.yml
+++ b/examples/workloads/crd-scale/templates/example-crd.yml
@@ -1,0 +1,29 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kubeburners{{.Iteration}}.cloudbulldozer.example.com
+spec:
+  group: cloudbulldozer.example.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                workload:
+                  type: string
+                iterations:
+                  type: integer
+  scope: Cluster
+  names:
+    plural: kubeburners{{.Iteration}}
+    singular: kubeburner{{.Iteration}}
+    kind: KubeBurner{{.Iteration}}
+    shortNames:
+    - kb{{.Iteration}}
+

--- a/pkg/workloads/crd-scale.go
+++ b/pkg/workloads/crd-scale.go
@@ -1,0 +1,43 @@
+// Copyright 2022 The Kube-burner Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workloads
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCrdScale holds the crd-scale workload
+func NewCrdScale(wh *WorkloadHelper) *cobra.Command {
+	var iterations int
+	cmd := &cobra.Command{
+		Use:          "crd-scale",
+		Short:        "Runs crd-scale workload",
+		SilenceUsage: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			wh.Metadata.Benchmark = cmd.Name()
+			os.Setenv("JOB_ITERATIONS", fmt.Sprint(iterations))
+
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			wh.run(cmd.Name(), MetricsProfileMap[cmd.Name()])
+		},
+	}
+	cmd.Flags().IntVar(&iterations, "iterations", 0, "Number of CRDs to create")
+	cmd.MarkFlagRequired("iterations")
+	return cmd
+}

--- a/pkg/workloads/workloads.go
+++ b/pkg/workloads/workloads.go
@@ -4,6 +4,7 @@ var MetricsProfileMap = map[string]string{
 	"cluster-density-ms": "metrics-aggregated.yml",
 	"cluster-density-v2": "metrics-aggregated.yml",
 	"cluster-density":    "metrics-aggregated.yml",
+	"crd-scale":          "metrics-aggregated.yml",
 	"node-density":       "metrics.yml",
 	"node-density-heavy": "metrics.yml",
 	"node-density-cni":   "metrics.yml",


### PR DESCRIPTION
This commit adds a new crd-scale workload under the ocp wrapper and also an example config file to run it standalone with the kube-burner command.
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [X] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
