### PR TITLE
Add new metrics for cpu seconds

### DIFF
--- a/cmd/kube-burner/ocp-config/metrics-aggregated.yml
+++ b/cmd/kube-burner/ocp-config/metrics-aggregated.yml
@@ -138,3 +138,32 @@
 
 - query: openshift:prometheus_tsdb_head_samples_appended_total:sum{job="prometheus-k8s"}
   metricName: prometheus-ingestionrate
+
+# Retain the raw CPU seconds totals for comparison
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="worker",role!="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Workers
+  instant: true
+
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Masters
+  instant: true
+
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Infra
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" } and on (node) kube_node_role{ role = "worker",role != "infra" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Workers
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "master" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Masters
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "infra" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Infra
+  instant: true
+
+- query: sum( container_cpu_usage_seconds_total{container!~"POD|",namespace=~"openshift-.*"} )  by (namespace)
+  metricName: cgroupCPUSeconds-namespaces
+  instant: true

--- a/cmd/kube-burner/ocp-config/metrics-report.yml
+++ b/cmd/kube-burner/ocp-config/metrics-report.yml
@@ -228,3 +228,32 @@
 - query: max_over_time(cluster:node_cpu:ratio[{{.elapsed}}:])
   metricName: max-cpu-cluster-usage-ratio
   instant: true
+
+# Retain the raw CPU seconds totals for comparison
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="worker",role!="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Workers
+  instant: true
+
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Masters
+  instant: true
+
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Infra
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" } and on (node) kube_node_role{ role = "worker",role != "infra" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Workers
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "master" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Masters
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "infra" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Infra
+  instant: true
+
+- query: sum( container_cpu_usage_seconds_total{container!~"POD|",namespace=~"openshift-.*"} )  by (namespace)
+  metricName: cgroupCPUSeconds-namespaces
+  instant: true

--- a/cmd/kube-burner/ocp-config/metrics.yml
+++ b/cmd/kube-burner/ocp-config/metrics.yml
@@ -129,3 +129,32 @@
 
 - query: openshift:prometheus_tsdb_head_samples_appended_total:sum{job="prometheus-k8s"}
   metricName: prometheus-ingestionrate
+
+# Retain the raw CPU seconds totals for comparison
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="worker",role!="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Workers
+  instant: true
+
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Masters
+  instant: true
+
+- query: sum( node_cpu_seconds_total and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)") ) by (mode)
+  metricName: nodeCPUSeconds-Infra
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" } and on (node) kube_node_role{ role = "worker",role != "infra" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Workers
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "master" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Masters
+  instant: true
+
+- query: sum (  container_cpu_usage_seconds_total {  id =~ "/system.slice|/system.slice/kubelet.service|/system.slice/ovs-vswitchd.service|/system.slice/crio.service|/kubepods.slice" }  and on (node) kube_node_role{ role = "infra" } )  by   (   id  )
+  metricName: cgroupCPUSeconds-Infra
+  instant: true
+
+- query: sum( container_cpu_usage_seconds_total{container!~"POD|",namespace=~"openshift-.*"} )  by (namespace)
+  metricName: cgroupCPUSeconds-namespaces
+  instant: true


### PR DESCRIPTION
## Type of change

- [X] New feature

## Description

I have found a lot of value in comparing the raw cpu_seconds aggregated at the few levels added here.

We currently index and report on the irate of these raw CPU seconds, but by using the raw seconds, we can report on the true cost of each change/component/namespace. This is just the first application of this kind of comparison.

They are important to have in all metrics profiles to make a meaningful comparison. They should be lighter than other metrics since we aren't retaining all nodes individually.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.