### PR TITLE
PreLoad images only in creation jobs

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -108,7 +108,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				log.Fatalf("Error creating clientSet: %s", err)
 			}
 			DynamicClient = dynamic.NewForConfigOrDie(restConfig)
-			if job.PreLoadImages {
+			if job.PreLoadImages && job.JobType == config.CreationJob {
 				if err = preLoadImages(job); err != nil {
 					log.Fatal(err.Error())
 				}

--- a/pkg/burner/patch.go
+++ b/pkg/burner/patch.go
@@ -106,7 +106,7 @@ func (ex *Executor) RunPatchJob() {
 			continue
 		}
 		log.Infof("Found %d %s with selector %s; patching them", len(itemList.Items), obj.gvr.Resource, labelSelector)
-		for i := 1; i < ex.JobIterations; i++ {
+		for i := 0; i < ex.JobIterations; i++ {
 			for _, item := range itemList.Items {
 				wg.Add(1)
 				go ex.patchHandler(obj, item, i, &wg)
@@ -120,7 +120,6 @@ func (ex *Executor) patchHandler(obj object, originalItem unstructured.Unstructu
 	iteration int, wg *sync.WaitGroup) {
 
 	defer wg.Done()
-
 	// There are several patch modes. Three of them are client-side, and one
 	// of them is server-side.
 	var data []byte


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

The preLoad stage should only be executed in creation jobs

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
