### PR TITLE
Set UUID in config in index and check-alerts subcommands

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -207,6 +207,7 @@ func indexCmd() *cobra.Command {
 			log.Info("👋 Exiting kube-burner ", uuid)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			configSpec.GlobalConfig.UUID = uuid
 			if esServer != "" && esIndex != "" {
 				configSpec.GlobalConfig.IndexerConfig = indexers.IndexerConfig{
 					Type:    indexers.ElasticIndexer,
@@ -311,10 +312,8 @@ func alertCmd() *cobra.Command {
 		Use:   "check-alerts",
 		Short: "Evaluate alerts for the given time range",
 		Args:  cobra.NoArgs,
-		PostRun: func(cmd *cobra.Command, args []string) {
-			log.Info("👋 Exiting kube-burner ", uuid)
-		},
 		Run: func(cmd *cobra.Command, args []string) {
+			configSpec.GlobalConfig.UUID = uuid
 			if esServer != "" && esIndex != "" {
 				configSpec.GlobalConfig.IndexerConfig = indexers.IndexerConfig{
 					Type:    indexers.ElasticIndexer,
@@ -351,8 +350,9 @@ func alertCmd() *cobra.Command {
 				log.Fatalf("Error creating alert manager: %s", err)
 			}
 
+			err = alertM.Evaluate(startTime, endTime)
 			log.Info("👋 Exiting kube-burner ", uuid)
-			if err := alertM.Evaluate(startTime, endTime); err != nil {
+			if err != nil {
 				os.Exit(1)
 			}
 		},


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We need to explicitly set the UUID in the config instance when using the index or check-alerts subcommands. UUID is actually set when parsing a configuration file, and that's not required anymore in these subcommands

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
