### PR TITLE
PVC Density/Stress

### DIFF
--- a/cmd/kube-burner/ocp-config/pvc-density/pod.yml
+++ b/cmd/kube-burner/ocp-config/pvc-density/pod.yml
@@ -1,0 +1,34 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  labels:
+    app: pvc-density-{{.Iteration}}
+  name: pod-{{.Iteration}}
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/worker
+            operator: Exists
+          - key: node-role.kubernetes.io/infra
+            operator: DoesNotExist
+          - key: node-role.kubernetes.io/workload
+            operator: DoesNotExist
+  tolerations:
+  - key: os
+    value: Windows
+    effect: NoSchedule
+  volumes:
+    - name: storage-stress-vlm-{{.Iteration}}
+      persistentVolumeClaim:
+        claimName: pvc-{{.Iteration}}
+  containers:
+  - image: {{.containerImage}}
+    name: pvc-density-container
+    resources:
+      requests:
+        memory: "10Mi"
+        cpu: "10m"
+    imagePullPolicy: IfNotPresent

--- a/cmd/kube-burner/ocp-config/pvc-density/pvc-density.yml
+++ b/cmd/kube-burner/ocp-config/pvc-density/pvc-density.yml
@@ -1,0 +1,55 @@
+---
+global:
+  gc: {{.GC}}
+  indexerConfig:
+    esServers: ["{{.ES_SERVER}}"]
+    insecureSkipVerify: true
+    defaultIndex: {{.ES_INDEX}}
+    type: {{.INDEXING_TYPE}}
+  measurements:
+    - name: podLatency
+
+jobs:
+  - name: add-default-storage
+    namespace: pvc-density
+    jobIterations: 1
+    namespacedIterations: false
+    podWait: false
+    waitWhenFinished: true
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+
+      - objectTemplate: storageclass.yml
+        inputVars:
+          storageProvisioner: {{.STORAGE_PROVISIONER}}
+        replicas: 1
+
+  - name: pvc-density
+    namespace: pvc-density
+    jobIterations: {{.JOB_ITERATIONS}}
+    cleanup: true
+    namespacedIterations: false
+    podWait: false
+    waitWhenFinished: true
+    preLoadImages: true
+    preLoadPeriod: 10s
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+
+      - objectTemplate: pvc.yml
+        replicas: 1
+        inputVars:
+          claimSize: {{.CLAIM_SIZE}}
+
+      - objectTemplate: pod.yml
+        replicas: 1
+        inputVars:
+          containerImage: registry.k8s.io/pause:3.1

--- a/cmd/kube-burner/ocp-config/pvc-density/pvc.yml
+++ b/cmd/kube-burner/ocp-config/pvc-density/pvc.yml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  labels:
+    app: pvc-density-{{.Iteration}}
+  name: pvc-{{.Iteration}}
+spec:
+  accessModes:
+  -  ReadWriteOnce
+  resources:
+    requests:
+      storage: {{.claimSize}}

--- a/cmd/kube-burner/ocp-config/pvc-density/storageclass.yml
+++ b/cmd/kube-burner/ocp-config/pvc-density/storageclass.yml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: pvc-density-sc
+  annotations:
+    storageclass.kubernetes.io/is-default-class: 'true'
+provisioner: {{.storageProvisioner}}

--- a/cmd/kube-burner/ocp.go
+++ b/cmd/kube-burner/ocp.go
@@ -100,6 +100,7 @@ func openShiftCmd() *cobra.Command {
 		workloads.NewNodeDensityHeavy(&wh),
 		workloads.NewNodeDensityCNI(&wh),
 		workloads.NewIndex(&wh.MetricsEndpoint, &wh.Metadata, &wh.OcpMetaAgent),
+		workloads.NewPVCDensity(&wh),
 	)
 	return ocpCmd
 }

--- a/pkg/workloads/pvc-density.go
+++ b/pkg/workloads/pvc-density.go
@@ -1,0 +1,64 @@
+package workloads
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var dynamicStorageProvisioners = map[string]string{
+	"aws":        "kubernetes.io/aws-ebs",
+	"cinder":     "kuberenetes.io/cinder",
+	"azure-disk": "kubernetes.io/azure-disk",
+	"azure-file": "kubernetes.io/azure-file",
+	"gce":        "kubernetes.io/gce-pd",
+	"ibm":        "powervs.csi.ibm.com",
+	"vsphere":    "kubernetes.io/vsphere-volume",
+}
+
+// NewPVCDensity holds pvc-density workload
+func NewPVCDensity(wh *WorkloadHelper) *cobra.Command {
+
+	var iterations int
+	var storageProvisioners []string
+	var claimSize string
+	var containerImage string
+	provisioner := "aws"
+
+	cmd := &cobra.Command{
+		Use:          "pvc-density",
+		Short:        "Runs pvc-density workload",
+		SilenceUsage: true,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			wh.Metadata.Benchmark = cmd.Name()
+			os.Setenv("JOB_ITERATIONS", fmt.Sprint(iterations))
+			os.Setenv("CONTAINER_IMAGE", containerImage)
+			os.Setenv("CLAIM_SIZE", fmt.Sprint(claimSize))
+
+			for key := range dynamicStorageProvisioners {
+				storageProvisioners = append(storageProvisioners, key)
+			}
+			re := regexp.MustCompile(`(?sm)^(cinder|azure\-disk|azure\-file|gce|ibm|vsphere|aws)$`)
+			if !re.MatchString(provisioner) {
+				log.Fatal(fmt.Errorf("%s does not match one of %s", provisioner, storageProvisioners))
+			}
+
+			os.Setenv("STORAGE_PROVISIONER", fmt.Sprint(dynamicStorageProvisioners[provisioner]))
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			wh.run(cmd.Name(), MetricsProfileMap[cmd.Name()])
+		},
+	}
+
+	cmd.Flags().IntVar(&iterations, "iterations", 0, fmt.Sprintf("%v iterations", iterations))
+	cmd.Flags().StringVar(&provisioner, "provisioner", provisioner, fmt.Sprintf(
+		"[%s]", strings.Join(storageProvisioners, " ")))
+	cmd.Flags().StringVar(&claimSize, "claim-size", "256Mi", "claim-size=256Mi")
+	cmd.Flags().StringVar(&containerImage, "container-image", "gcr.io/google_containers/pause:3.1", "Container image")
+
+	return cmd
+}

--- a/pkg/workloads/workloads.go
+++ b/pkg/workloads/workloads.go
@@ -11,4 +11,5 @@ var MetricsProfileMap = map[string]string{
 	"networkpolicy-multitenant":      "metrics.yml",
 	"networkpolicy-matchlabels":      "metrics.yml",
 	"networkpolicy-matchexpressions": "metrics.yml",
+	"pvc-density":                    "metrics.yml",
 }

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -93,3 +93,11 @@ teardown_file() {
   run kube-burner ocp networkpolicy-multitenant --iterations 5  ${COMMON_FLAGS}
   [ "$status" -eq 0 ]
 }
+
+@test "pvc-density" {
+  # Since 'aws' is the chosen storage provisioner, this will only execute successfully if the ocp environment is aws
+  run kube-burner ocp pvc-density --iterations=2 --provisioner=aws
+  [ "$status" -eq 0 ]
+  run check_metric_value clusterMetadata jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement
+  [ "$status" -eq 0 ]
+}

--- a/test/test-ocp.bats
+++ b/test/test-ocp.bats
@@ -96,7 +96,7 @@ teardown_file() {
 
 @test "pvc-density" {
   # Since 'aws' is the chosen storage provisioner, this will only execute successfully if the ocp environment is aws
-  run kube-burner ocp pvc-density --iterations=2 --provisioner=aws
+  run kube-burner ocp pvc-density --iterations=2 --provisioner=aws ${COMMON_FLAGS}
   [ "$status" -eq 0 ]
   run check_metric_value clusterMetadata jobSummary podLatencyMeasurement podLatencyQuantilesMeasurement
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add an experiment that creates a lot of Pods with corresponding PVCs that supports the default dynamic storage provisioning in a computing environment.

[gist of kube-burner standard output log](https://gist.github.com/mfleader/433acdac8b888e5bddccf0d842e720c1)

This software experiment would be aided by something like a PVC or PV latency calculation, similar to the pod latency calculation.

## Related Tickets & Documents

- Related Issue #427 
- Closes #427

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
