### PR TITLE
Reverting to older timestamp format in logs

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -393,7 +393,7 @@ func main() {
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		log.SetReportCaller(true)
 		formatter := &log.TextFormatter{
-			TimestampFormat: time.RFC3339,
+			TimestampFormat: "2006-01-02 15:04:05",
 			FullTimestamp:   true,
 			DisableColors:   true,
 			CallerPrettyfier: func(f *runtime.Frame) (function string, file string) {


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
As per our discussion offline https://redhat-internal.slack.com/archives/C05CDC19ZKJ/p1695741562501689, 
Reverting to our previous time format in logs.
```
"2006-01-02 15:04:05"
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested on a local machine.
```
time="2023-09-26 12:12:06" level=info msg="👽 Initializing prometheus client with URL: https://prometheus-k8s-openshift-monitoring.apps.play-area.perfscale.devcluster.openshift.com" file="prometheus.go:45"
time="2023-09-26 12:12:07" level=info msg="🔥 Starting kube-burner (oldtimeformat@56e243a16053ac5c7998ecb01766c85dba35bd0d) with UUID 6da716de-43ad-4584-96c5-44fb3e00ffb0" file="job.go:97"
time="2023-09-26 12:12:07" level=info msg="📈 Registered measurement: podLatency" file="factory.go:84"
time="2023-09-26 12:12:07" level=debug msg="Preparing create job: node-density-heavy" file="create.go:52"
time="2023-09-26 12:12:07" level=debug msg="Rendering template: postgres-deployment.yml" file="create.go:59"
time="2023-09-26 12:12:07" level=info msg="Job node-density-heavy: 30 iterations with 1 Deployment replicas" file="create.go:96"
time="2023-09-26 12:12:07" level=debug msg="Rendering template: app-deployment.yml" file="create.go:59"
```
