### PR TITLE
Adding instantJobStart feature

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -16,12 +16,17 @@ The metrics profile file has the following structure:
 
 The `query` field holds the Prometheus expression to evaluate, and `metricName` controls the value that kube-burner will set on the `metricName` field. This is useful to identify metrics from a specific query. More information is available in the [metric format section](#metric-format).
 
-In addition to range queries, kube-burner has the ability perform instant queries by adding the field `instant` to the desired metric. This kind of query is especially useful to get only one sample of a *static* metric, such as a component version or the number of nodes of the cluster.
+In addition to range queries, kube-burner has the ability perform instant queries by adding the field `instant` to the desired metric. This kind of query is especially useful to get only one datapoint of a certain expression, such as a component version or the number of nodes of the cluster. By default this datapoint is taken using the ending timestamp of the job, but it's possible to get fetch it using the first timestamp of the job by enabling the flag `instantJobStart`.
 
 ```yaml
-- query: kube_node_role
-  metricName: nodeRoles
+- query: sum(node_cpu_seconds_total{mode!="idle"})
+  metricName: endingCPUSeconds
   instant: true
+
+- query: sum(node_cpu_seconds_total{mode!="idle"})
+  metricName: initialCPUSeconds
+  instant: true
+  instantJobStart: true
 ```
 
 ## Metric format
@@ -64,7 +69,6 @@ The collected metrics have the following shape:
 Notice that kube-burner enriches the query results by adding some extra fields like `uuid`, `query`, `metricName` and `jobName`.
 !!! info
     These extra fields are especially useful at the time of identifying and representing the collected metrics.
-
 
 ## Using the elapsed variable
 

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cloud-bulldozer/kube-burner/pkg/config"
 )
 
+type InstantTimestamp string
+
 type Auth struct {
 	Username      string
 	Password      string
@@ -49,9 +51,10 @@ type Job struct {
 
 // metricDefinition describes what metrics kube-burner collects
 type metricDefinition struct {
-	Query      string `yaml:"query"`
-	MetricName string `yaml:"metricName"`
-	Instant    bool   `yaml:"instant"`
+	Query           string `yaml:"query"`
+	MetricName      string `yaml:"metricName"`
+	Instant         bool   `yaml:"instant"`
+	InstantJobStart bool   `yaml:"instantJobStart"`
 }
 
 // MetricEndpoint describes prometheus endpoint to scrape

--- a/test/k8s/metrics-profile.yaml
+++ b/test/k8s/metrics-profile.yaml
@@ -8,3 +8,8 @@
 - query: prometheus_build_info
   metricName: prometheusBuildInfo
   instant: true
+
+- query: prometheus_build_info
+  metricName: prometheusBuildInfo
+  instant: true
+  instantJobStart: true


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adding `instantJobStart` so we can fetch the first datapoint of a timeseries during a job.

## Related Tickets & Documents

- Related Issue #
- Closes [#](https://github.com/cloud-bulldozer/kube-burner/issues/482)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
