### PR TITLE
Bump prometheus alerts severity to error

### DIFF
--- a/cmd/kube-burner/ocp-config/alerts.yml
+++ b/cmd/kube-burner/ocp-config/alerts.yml
@@ -36,7 +36,7 @@
 
 - expr: up{namespace=~"openshift-etcd"} == 0
   description: "{{$labels.namespace}}/{{$labels.pod}} down"
-  severity: error
+  severity: warning
 
 - expr: up{namespace=~"openshift-.*(kube-controller-manager|scheduler|controller-manager|sdn|ovn-kubernetes|dns)"} == 0
   description: "{{$labels.namespace}}/{{$labels.pod}} down"
@@ -58,4 +58,4 @@
 # Prometheus alerts
 - expr: ALERTS{severity="critical", alertstate="firing"} > 0
   description: Critical prometheus alert. {{$labels.alertname}}
-  severity: warning
+  severity: error

--- a/pkg/alerting/alert_manager.go
+++ b/pkg/alerting/alert_manager.go
@@ -54,11 +54,11 @@ type alertProfile []struct {
 
 // alert definition
 type alert struct {
-	Timestamp   time.Time `json:"timestamp"`
-	UUID        string    `json:"uuid"`
-	Severity    string    `json:"severity"`
-	Description string    `json:"description"`
-	MetricName  string    `json:"metricName"`
+	Timestamp   time.Time     `json:"timestamp"`
+	UUID        string        `json:"uuid"`
+	Severity    severityLevel `json:"severity"`
+	Description string        `json:"description"`
+	MetricName  string        `json:"metricName"`
 }
 
 // AlertManager configuration
@@ -186,7 +186,7 @@ func parseMatrix(value model.Value, description string, severity severityLevel) 
 			msg := fmt.Sprintf("alert at %v: '%s'", val.Timestamp.Time().UTC().Format(time.RFC3339), renderedDesc.String())
 			alertSet = append(alertSet, alert{
 				Timestamp:   val.Timestamp.Time().UTC(),
-				Severity:    string(severity),
+				Severity:    severity,
 				Description: renderedDesc.String(),
 				MetricName:  alertMetricName,
 			})


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Bumping detected in-cluster Prometheus alerts severity to error. kube-burner will return 1 in case of running into at least one of these alerts.

The rule kube-burner evaluates is

```
ALERTS{severity="critical", alertstate="firing"} > 0
```

which just tracks critical alerts in firing state, we could consider tracking alerts in error state as well, but maybe that would be too noisy

cc: @paigerube14  @svetsa-rh

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
