### PR TITLE
skipIndexing feature

### DIFF
--- a/cmd/kube-burner/ocp-config/networkpolicy-matchexpressions/networkpolicy-matchexpressions.yml
+++ b/cmd/kube-burner/ocp-config/networkpolicy-matchexpressions/networkpolicy-matchexpressions.yml
@@ -12,6 +12,7 @@ global:
 jobs:
   - name: create-bindings
     namespace: networkpolicy-matchexpressions
+    skipIndexing: true
     jobIterations: 1
     objects:
       - objectTemplate: ../clusterrole.yml

--- a/cmd/kube-burner/ocp-config/networkpolicy-matchlabels/networkpolicy-matchlabels.yml
+++ b/cmd/kube-burner/ocp-config/networkpolicy-matchlabels/networkpolicy-matchlabels.yml
@@ -12,6 +12,7 @@ global:
 jobs:
   - name: create-bindings
     namespace: networkpolicy-matchlabels
+    skipIndexing: true
     jobIterations: 1
     objects:
       - objectTemplate: ../clusterrole.yml

--- a/cmd/kube-burner/ocp-config/networkpolicy-multitenant/networkpolicy-multitenant.yml
+++ b/cmd/kube-burner/ocp-config/networkpolicy-multitenant/networkpolicy-multitenant.yml
@@ -12,6 +12,7 @@ global:
 jobs:
   - name: create-bindings
     namespace: networkpolicy-multitenant
+    skipIndexing: true
     jobIterations: 1
     objects:
       - objectTemplate: ../clusterrole.yml

--- a/cmd/kube-burner/ocp-config/pvc-density/pvc-density.yml
+++ b/cmd/kube-burner/ocp-config/pvc-density/pvc-density.yml
@@ -16,6 +16,7 @@ jobs:
     namespacedIterations: false
     podWait: false
     waitWhenFinished: true
+    skipIndexing: true
     namespaceLabels:
       security.openshift.io/scc.podSecurityLabelSync: false
       pod-security.kubernetes.io/enforce: privileged

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -62,6 +62,7 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | `objects`              | List of objects the job will create. Detailed on the [objects section](#objects) | List    | []      |
 | `verifyObjects`        | Verify object count after running each job                                       | Boolean | true    |
 | `errorOnVerify`        | Set RC to 1 when objects verification fails                                      | Boolean | true    |
+| `skipIndexing`         | Skip metric indexing on this job                                                 | Boolean | false   |
 | `preLoadImages`        | Kube-burner will create a DS before triggering the job to pull all the images of the job   | true    |
 | `preLoadPeriod`        | How long to wait for the preload daemonset                                       | Duration| 1m     |
 | `preloadNodeLabels`    | Add node selector labels for the resources created in preload stage              | Object  | {} |

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -220,7 +220,11 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 					EndTimstamp: job.End,
 					ElapsedTime: elapsedTime,
 				}
-				indexjobSummaryInfo(indexer, uuid, jobTimings, job.JobConfig, metadata)
+				if job.JobConfig.SkipIndexing {
+					log.Infof("Skipping job summary indexing in job: %s", job.JobConfig.Name)
+				} else {
+					indexjobSummaryInfo(indexer, uuid, jobTimings, job.JobConfig, metadata)
+				}
 			}
 		}
 		for idx, prometheusClient := range prometheusClients {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -158,6 +158,8 @@ type Job struct {
 	ChurnDuration time.Duration `yaml:"churnDuration" json:"churnDuration,omitempty"`
 	// Churn delay between sets
 	ChurnDelay time.Duration `yaml:"churnDelay" json:"churnDelay,omitempty"`
+	// Skip this job from indexing
+	SkipIndexing bool `yaml:"skipIndexing" json:"skipIndexing,omitempty"`
 }
 
 type WaitOptions struct {

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -169,8 +169,12 @@ func (p *podLatency) stop() error {
 		err = metrics.CheckThreshold(p.config.LatencyThresholds, p.latencyQuantiles)
 	}
 	if globalCfg.IndexerConfig.Type != "" {
-		log.Infof("Indexing pod latency data for job: %s", factory.jobConfig.Name)
-		p.index()
+		if factory.jobConfig.SkipIndexing {
+			log.Infof("Skipping pod latency data indexing in job")
+		} else {
+			log.Infof("Indexing pod latency data for job: %s", factory.jobConfig.Name)
+			p.index()
+		}
 	}
 	for _, q := range p.latencyQuantiles {
 		pq := q.(metrics.LatencyQuantiles)

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -71,6 +71,10 @@ func (p *Prometheus) ScrapeJobsMetrics(indexer *indexers.Indexer) error {
 	vars["elapsed"] = fmt.Sprintf("%ds", elapsed)
 	docsToIndex := make(map[string][]interface{})
 	for _, eachJob := range p.JobList {
+		if eachJob.JobConfig.SkipIndexing {
+			log.Infof("Skipping indexing in job: %v", eachJob.JobConfig.Name)
+			continue
+		}
 		jobStart := eachJob.Start
 		jobEnd := eachJob.End
 		log.Info("Scraping metrics for job: ", eachJob.JobConfig.Name)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [x] Documentation Update

## Description

Ability to skip indexing on certain jobs, useful to prevent capturing datapoints from setup-up jobs

@mohit-sheth I've taken the liberty of adding this flag to the networkPolicy workloads, wdyt?

@josecastillolema I think this might be useful for web-burner as there're some set-up steps in the jobs you probably don't need to capture

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
