### PR TITLE
Fixing client-side throttling in wait stage

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -44,7 +44,7 @@ func setupCreateJob(jobConfig config.Job) Executor {
 	var err error
 	var f io.Reader
 	mapper := newRESTMapper()
-	waitClientSet, waitRestConfig, err = config.GetClientSet(jobConfig.QPS*2, jobConfig.Burst*2)
+	waitClientSet, waitRestConfig, err = config.GetClientSet(float32(int(jobConfig.QPS)*len(jobConfig.Objects)), jobConfig.Burst*len(jobConfig.Objects))
 	if err != nil {
 		log.Fatalf("Error creating wait clientSet: %s", err.Error())
 	}
@@ -163,7 +163,7 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 	if ex.WaitWhenFinished {
 		log.Infof("Waiting up to %s for actions to be completed", ex.MaxWaitTimeout)
 		// This semaphore is used to limit the maximum number of concurrent goroutines
-		sem := make(chan int, int(ClientSet.RESTClient().GetRateLimiter().QPS())*2)
+		sem := make(chan int, int(waitRestConfig.QPS))
 		for i := iterationStart; i < iterationEnd; i++ {
 			if ex.NamespacedIterations {
 				ns = ex.generateNamespace(i)

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -99,7 +99,7 @@ func setupCreateJob(jobConfig config.Job) Executor {
 
 // RunCreateJob executes a creation job
 func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNamespaces *[]string) {
-	waitLimiter := rate.NewLimiter(rate.Limit(waitRestConfig.QPS), waitRestConfig.Burst)
+	waitLimiter := rate.NewLimiter(rate.Limit(restConfig.QPS), restConfig.Burst)
 	nsLabels := map[string]string{
 		"kube-burner-job":   ex.Name,
 		"kube-burner-uuid":  ex.uuid,
@@ -162,7 +162,7 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 	if ex.WaitWhenFinished {
 		log.Infof("Waiting up to %s for actions to be completed", ex.MaxWaitTimeout)
 		// This semaphore is used to limit the maximum number of concurrent goroutines
-		sem := make(chan int, int(waitRestConfig.QPS))
+		sem := make(chan int, int(restConfig.QPS))
 		for i := iterationStart; i < iterationEnd; i++ {
 			if ex.NamespacedIterations {
 				ns = ex.generateNamespace(i)

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cloud-bulldozer/kube-burner/pkg/config"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
 
 	"github.com/cloud-bulldozer/kube-burner/pkg/util"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,18 +38,15 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/dynamic"
 )
 
 func setupCreateJob(jobConfig config.Job) Executor {
 	var err error
 	var f io.Reader
 	mapper := newRESTMapper()
-	waitClientSet, waitRestConfig, err = config.GetClientSet(float32(int(jobConfig.QPS)*len(jobConfig.Objects)), jobConfig.Burst*len(jobConfig.Objects))
 	if err != nil {
 		log.Fatalf("Error creating wait clientSet: %s", err.Error())
 	}
-	waitDynamicClient = dynamic.NewForConfigOrDie(waitRestConfig)
 	log.Debugf("Preparing create job: %s", jobConfig.Name)
 	ex := Executor{}
 	for _, o := range jobConfig.Objects {
@@ -101,6 +99,7 @@ func setupCreateJob(jobConfig config.Job) Executor {
 
 // RunCreateJob executes a creation job
 func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNamespaces *[]string) {
+	waitLimiter := rate.NewLimiter(rate.Limit(waitRestConfig.QPS), waitRestConfig.Burst)
 	nsLabels := map[string]string{
 		"kube-burner-job":   ex.Name,
 		"kube-burner-uuid":  ex.uuid,
@@ -149,7 +148,7 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 			if !ex.NamespacedIterations || !namespacesWaited[ns] {
 				log.Infof("Waiting up to %s for actions to be completed in namespace %s", ex.MaxWaitTimeout, ns)
 				wg.Wait()
-				ex.waitForObjects(ns)
+				ex.waitForObjects(ns, waitLimiter)
 				namespacesWaited[ns] = true
 			}
 		}
@@ -176,7 +175,7 @@ func (ex *Executor) RunCreateJob(iterationStart, iterationEnd int, waitListNames
 			sem <- 1
 			wg.Add(1)
 			go func(ns string) {
-				ex.waitForObjects(ns)
+				ex.waitForObjects(ns, waitLimiter)
 				<-sem
 				wg.Done()
 			}(ns)

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -306,7 +306,7 @@ func runWaitList(globalWaitMap map[string][]string, executorMap map[string]Execu
 		executor := executorMap[executorUUID]
 		log.Infof("Waiting up to %s for actions to be completed", executor.MaxWaitTimeout)
 		// This semaphore is used to limit the maximum number of concurrent goroutines
-		sem := make(chan int, int(ClientSet.RESTClient().GetRateLimiter().QPS())*2)
+		sem := make(chan int, int(waitRestConfig.QPS))
 		for _, ns := range namespaces {
 			sem <- 1
 			wg.Add(1)

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -113,7 +113,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 				log.Fatalf("Error creating clientSet: %s", err)
 			}
 			discoveryClient = discovery.NewDiscoveryClientForConfigOrDie(restConfig)
-			waitClientSet, waitRestConfig, err = config.GetClientSet(float32(int(job.QPS)*len(job.Objects)), job.Burst*len(job.Objects))
+			waitClientSet, waitRestConfig, err = config.GetClientSet(job.QPS, job.Burst)
 			if err != nil {
 				log.Fatalf("Error creating clientSet: %s", err)
 			}

--- a/pkg/burner/waiters.go
+++ b/pkg/burner/waiters.go
@@ -75,7 +75,7 @@ func (ex *Executor) waitForObjects(ns string, limiter *rate.Limiter) {
 func waitForDeployments(ns string, maxWaitTimeout time.Duration) {
 	// TODO handle errors such as timeouts
 	wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
-		deps, err := waitClientSet.AppsV1().Deployments(ns).List(context.TODO(), metav1.ListOptions{})
+		deps, err := ClientSet.AppsV1().Deployments(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -91,7 +91,7 @@ func waitForDeployments(ns string, maxWaitTimeout time.Duration) {
 
 func waitForRS(ns string, maxWaitTimeout time.Duration) {
 	wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
-		rss, err := waitClientSet.AppsV1().ReplicaSets(ns).List(context.TODO(), metav1.ListOptions{})
+		rss, err := ClientSet.AppsV1().ReplicaSets(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -107,7 +107,7 @@ func waitForRS(ns string, maxWaitTimeout time.Duration) {
 
 func waitForStatefulSet(ns string, maxWaitTimeout time.Duration) {
 	wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
-		stss, err := waitClientSet.AppsV1().StatefulSets(ns).List(context.TODO(), metav1.ListOptions{})
+		stss, err := ClientSet.AppsV1().StatefulSets(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -123,7 +123,7 @@ func waitForStatefulSet(ns string, maxWaitTimeout time.Duration) {
 
 func waitForPVC(ns string, maxWaitTimeout time.Duration) {
 	wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
-		pvc, err := waitClientSet.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase!=Bound"})
+		pvc, err := ClientSet.CoreV1().PersistentVolumeClaims(ns).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase!=Bound"})
 		if err != nil {
 			return false, err
 		}
@@ -133,7 +133,7 @@ func waitForPVC(ns string, maxWaitTimeout time.Duration) {
 
 func waitForRC(ns string, maxWaitTimeout time.Duration) {
 	wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
-		rcs, err := waitClientSet.CoreV1().ReplicationControllers(ns).List(context.TODO(), metav1.ListOptions{})
+		rcs, err := ClientSet.CoreV1().ReplicationControllers(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -149,7 +149,7 @@ func waitForRC(ns string, maxWaitTimeout time.Duration) {
 
 func waitForDS(ns string, maxWaitTimeout time.Duration) {
 	wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
-		dss, err := waitClientSet.AppsV1().DaemonSets(ns).List(context.TODO(), metav1.ListOptions{})
+		dss, err := ClientSet.AppsV1().DaemonSets(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -165,7 +165,7 @@ func waitForDS(ns string, maxWaitTimeout time.Duration) {
 
 func waitForPod(ns string, maxWaitTimeout time.Duration) {
 	wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
-		pods, err := waitClientSet.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase!=Running"})
+		pods, err := ClientSet.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase!=Running"})
 		if err != nil {
 			return false, err
 		}
@@ -182,7 +182,7 @@ func waitForBuild(ns string, maxWaitTimeout time.Duration, expected int) {
 		Resource: types.OpenShiftBuildResource,
 	}
 	wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
-		builds, err := waitDynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
+		builds, err := DynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -225,9 +225,9 @@ func verifyCondition(gvr schema.GroupVersionResource, ns, condition string, maxW
 	wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		var objs *unstructured.UnstructuredList
 		if ns != "" {
-			objs, err = waitDynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
+			objs, err = DynamicClient.Resource(gvr).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
 		} else {
-			objs, err = waitDynamicClient.Resource(gvr).List(context.TODO(), metav1.ListOptions{})
+			objs, err = DynamicClient.Resource(gvr).List(context.TODO(), metav1.ListOptions{})
 		}
 		if err != nil {
 			return false, err
@@ -282,7 +282,7 @@ func waitForVMIRS(ns string, maxWaitTimeout time.Duration) {
 		Resource: types.VirtualMachineInstanceReplicaSetResource,
 	}
 	wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, maxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
-		objs, err := waitDynamicClient.Resource(vmiGVRRS).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
+		objs, err := DynamicClient.Resource(vmiGVRRS).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			log.Debugf("VMIRS error %v", err)
 			return false, err

--- a/pkg/burner/waiters.go
+++ b/pkg/burner/waiters.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,7 +30,8 @@ import (
 	"github.com/cloud-bulldozer/kube-burner/pkg/burner/types"
 )
 
-func (ex *Executor) waitForObjects(ns string) {
+func (ex *Executor) waitForObjects(ns string, limiter *rate.Limiter) {
+	limiter.Wait(context.TODO())
 	for _, obj := range ex.objects {
 		if obj.Wait {
 			if obj.WaitOptions.ForCondition != "" {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR tries to fix some race conditions on the "wait" logic that lead to observe a high amount of client-side throttling.
This client-side throttling can happen because originally kube-burner was creating a new goroutine for each object found in the job. That's to say, in a job with 5 objects, kube-burner can create up to 5 goroutines running in parallel , the problem with this approach is that the each one of these goroutines is spawned from another goroutine, which is limited to QPSx2. So in a worse case scenario with QPS/Burst=20/20 and 5 objects in a job we could see up to 20x2x5 = 200 requests in parallel which is way larger than the configured ClientSet rate limiter (QPSx2=40).

The new approach stops using children goroutines for the objects in a job, each namespace/iteration has its own goroutine and the the objects in it are waited one after another.

This new approach can have several side-effects we've to analyze:
- Extra wait time.
- Different load in the server side, the number of simultaneous requests now is similar to the configures QPS/Burst values

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
