### PR TITLE
Fix index subcommands to append jobName and uuid

### DIFF
--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -43,7 +43,6 @@ type Prometheus struct {
 type Job struct {
 	Start     time.Time
 	End       time.Time
-	Name      string
 	JobConfig config.Job
 }
 

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
 	"github.com/cloud-bulldozer/kube-burner/pkg/alerting"
+	"github.com/cloud-bulldozer/kube-burner/pkg/config"
 	"github.com/cloud-bulldozer/kube-burner/pkg/prometheus"
 	"github.com/cloud-bulldozer/kube-burner/pkg/util"
 	log "github.com/sirupsen/logrus"
@@ -111,7 +112,9 @@ func ProcessMetricsScraperConfig(metricsScraperConfig ScraperConfig) Scraper {
 			p.JobList = []prometheus.Job{{
 				Start: time.Unix(metricsScraperConfig.StartTime, 0),
 				End:   time.Unix(metricsScraperConfig.EndTime, 0),
-				Name:  metricsScraperConfig.JobName,
+				JobConfig: config.Job{
+					Name: metricsScraperConfig.JobName,
+				},
 			},
 			}
 			p.ScrapeJobsMetrics(indexer)

--- a/pkg/workloads/index.go
+++ b/pkg/workloads/index.go
@@ -38,7 +38,7 @@ func NewIndex(metricsEndpoint *string, metadata *BenchmarkMetadata, ocpMetaAgent
 		Long:         "If no other indexer is specified, local indexer is used by default",
 		SilenceUsage: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			uuid, _ = cmd.Flags().GetString("uuid")
+			uuid, _ = cmd.InheritedFlags().GetString("uuid")
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			log.Info("👋 Exiting kube-burner ", uuid)
@@ -58,6 +58,7 @@ func NewIndex(metricsEndpoint *string, metadata *BenchmarkMetadata, ocpMetaAgent
 			}
 			esServer, _ := cmd.Flags().GetString("es-server")
 			esIndex, _ := cmd.Flags().GetString("es-index")
+			configSpec.GlobalConfig.UUID = uuid
 			if esServer != "" && esIndex != "" {
 				configSpec.GlobalConfig.IndexerConfig = indexers.IndexerConfig{
 					Type:    indexers.ElasticIndexer,
@@ -87,7 +88,7 @@ func NewIndex(metricsEndpoint *string, metadata *BenchmarkMetadata, ocpMetaAgent
 				Token:           prometheusToken,
 				StartTime:       start,
 				EndTime:         end,
-				JobName:         jobName + "-" + uuid,
+				JobName:         jobName,
 				ActionIndex:     true,
 				UserMetaData:    userMetadata,
 				OcpMetaData:     ocpMetadata,


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We weren't appending jobName to the metrics since https://github.com/cloud-bulldozer/kube-burner/pull/484
The uuid wasn't being set correctly in the index ocp subcommand 

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
