### PR TITLE
Implementing topology spread constraints

### DIFF
--- a/cmd/kube-burner/ocp-config/cluster-density-ms/deployment.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density-ms/deployment.yml
@@ -7,12 +7,20 @@ spec:
   replicas: {{.podReplicas}}
   selector:
     matchLabels:
-      app: cluster-density-{{.Replica}}
+      name: cluster-density-{{.Replica}}
   template:
     metadata:
       labels:
-        app: cluster-density-{{.Replica}}
+        name: cluster-density-{{.Replica}}
+        app: cluster-density-ms
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1 
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway 
+        labelSelector: 
+          matchLabels:
+            app: cluster-density-ms
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/kube-burner/ocp-config/cluster-density-ms/service.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density-ms/service.yml
@@ -5,7 +5,7 @@ metadata:
   name: cluster-density-{{.Replica}}
 spec:
   selector:
-    app: cluster-density-{{.Replica}}
+    name: cluster-density-{{.Replica}}
   ports:
   - name: http
     protocol: TCP

--- a/cmd/kube-burner/ocp-config/cluster-density-v2/deployment-client.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density-v2/deployment-client.yml
@@ -6,13 +6,20 @@ spec:
   replicas: {{.podReplicas}}
   selector:
     matchLabels:
-      app: client-{{.Replica}}
+      name: client-{{.Replica}}
   template:
     metadata:
       labels:
-        app: client-{{.Replica}}
-        name: client
+        name: client-{{.Replica}}
+        app: client
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1 
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway 
+        labelSelector: 
+          matchLabels:
+            app: client
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/kube-burner/ocp-config/cluster-density-v2/deployment-server.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density-v2/deployment-server.yml
@@ -7,13 +7,20 @@ spec:
   replicas: {{.podReplicas}}
   selector:
     matchLabels:
-      app: cluster-density-{{.Replica}}
+      name: cluster-density-{{.Replica}}
   template:
     metadata:
       labels:
-        app: cluster-density-{{.Replica}}
-        name: nginx
+        name: cluster-density-{{.Replica}}
+        app: nginx
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1 
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway 
+        labelSelector: 
+          matchLabels:
+            app: nginx
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/kube-burner/ocp-config/cluster-density-v2/np-allow-from-clients.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density-v2/np-allow-from-clients.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      name: nginx
+      app: nginx
   ingress:
   - from:
     - namespaceSelector:

--- a/cmd/kube-burner/ocp-config/cluster-density-v2/service.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density-v2/service.yml
@@ -5,7 +5,7 @@ metadata:
   name: cluster-density-{{.Replica}}
 spec:
   selector:
-    name: nginx
+    app: nginx
   ports:
   - name: http
     protocol: TCP

--- a/cmd/kube-burner/ocp-config/cluster-density/deployment.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density/deployment.yml
@@ -7,12 +7,20 @@ spec:
   replicas: {{.podReplicas}}
   selector:
     matchLabels:
-      app: cluster-density-{{.Replica}}
+      name: cluster-density-{{.Replica}}
   template:
     metadata:
       labels:
-        app: cluster-density-{{.Replica}}
+        name: cluster-density-{{.Replica}}
+        app: cluster-density
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1 
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway 
+        labelSelector: 
+          matchLabels:
+            app: cluster-density
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/kube-burner/ocp-config/cluster-density/service.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density/service.yml
@@ -5,7 +5,7 @@ metadata:
   name: cluster-density-{{.Replica}}
 spec:
   selector:
-    app: cluster-density-{{.Replica}}
+    name: cluster-density-{{.Replica}}
   ports:
   - name: http
     protocol: TCP

--- a/cmd/kube-burner/ocp-config/node-density-cni/curl-deployment.yml
+++ b/cmd/kube-burner/ocp-config/node-density-cni/curl-deployment.yml
@@ -7,7 +7,15 @@ spec:
     metadata:
       labels:
         name: curl-{{.Replica}}-{{.Iteration}}
+        app: curl
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1 
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway 
+        labelSelector: 
+          matchLabels:
+            app: curl
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/kube-burner/ocp-config/node-density-cni/webserver-deployment.yml
+++ b/cmd/kube-burner/ocp-config/node-density-cni/webserver-deployment.yml
@@ -7,7 +7,15 @@ spec:
     metadata:
       labels:
         name: webserver-{{.Replica}}-{{.Iteration}}
+        app: webserver
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1 
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway 
+        labelSelector: 
+          matchLabels:
+            app: webserver
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/kube-burner/ocp-config/node-density-heavy/app-deployment.yml
+++ b/cmd/kube-burner/ocp-config/node-density-heavy/app-deployment.yml
@@ -7,7 +7,15 @@ spec:
     metadata:
       labels:
         name: perfapp-{{.Replica}}-{{.Iteration}}
+        app: perfapp
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1 
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway 
+        labelSelector: 
+          matchLabels:
+            app: perfapp
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/kube-burner/ocp-config/node-density-heavy/postgres-deployment.yml
+++ b/cmd/kube-burner/ocp-config/node-density-heavy/postgres-deployment.yml
@@ -7,7 +7,15 @@ spec:
     metadata:
       labels:
         name: postgres-{{.Replica}}-{{.Iteration}}
+        app: postgres
     spec:
+      topologySpreadConstraints:
+      - maxSkew: 1 
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway 
+        labelSelector: 
+          matchLabels:
+            app: postgres
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/kube-burner/ocp-config/node-density/pod.yml
+++ b/cmd/kube-burner/ocp-config/node-density/pod.yml
@@ -2,9 +2,17 @@ kind: Pod
 apiVersion: v1
 metadata:
   labels:
-    app: node-density-{{.Iteration}}
+    name: node-density-{{.Iteration}}
+    app: pause
   name: {{.JobName}}-{{.Iteration}}
 spec:
+  topologySpreadConstraints:
+  - maxSkew: 1 
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway 
+    labelSelector: 
+      matchLabels:
+        app: pause
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

Implementing topology spread constraints in OCP workloads to help in evenly pod distribution 

Not patched:
```shell
$ ./bin/amd64/kube-burner ocp node-density-heavy --pods-per-node=100
<truncated>
$ kubectl get pods -n node-density-heavy-0 --field-selector=status.phase=Running -o go-template --template='{{range .items}}{{.spec.nodeName}}{{"\n"}}{{end}}'  | awk '{nodes[$1]++ }END{ for (n in nodes) print n": "nodes[n]}'
ip-10-0-133-30.us-west-2.compute.internal: 26
ip-10-0-173-62.us-west-2.compute.internal: 13
ip-10-0-217-162.us-west-2.compute.internal: 75
``` 

Patched:
```shell
$ ./bin/amd64/kube-burner ocp node-density-heavy --pods-per-node=100
<truncated>
$ kubectl get pods -n node-density-heavy-0 --field-selector=status.phase=Running -o go-template --template='{{range .items}}{{.spec.nodeName}}{{"\n"}}{{end}}'  | awk '{nodes[$1]++ }END{ for (n in nodes) print n": "nodes[n]}'
ip-10-0-133-30.us-west-2.compute.internal: 38
ip-10-0-173-62.us-west-2.compute.internal: 36
ip-10-0-217-162.us-west-2.compute.internal: 38
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
