### PR TITLE
Simplifying metrics configuration logic

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -246,7 +246,7 @@ func indexCmd() *cobra.Command {
 					log.Fatal(err)
 				}
 			}
-			if tarballName != "" {
+			if configSpec.GlobalConfig.IndexerConfig.Type == indexers.LocalIndexer && tarballName != "" {
 				if err := metrics.CreateTarball(configSpec.GlobalConfig.IndexerConfig, tarballName); err != nil {
 					log.Fatal(err)
 				}
@@ -269,7 +269,7 @@ func indexCmd() *cobra.Command {
 	cmd.Flags().StringVar(&metricsDirectory, "metrics-directory", "collected-metrics", "Directory to dump the metrics files in, when using default local indexing")
 	cmd.Flags().StringVar(&esServer, "es-server", "", "Elastic Search endpoint")
 	cmd.Flags().StringVar(&esIndex, "es-index", "", "Elastic Search index")
-	cmd.Flags().StringVar(&tarballName, "tarball-name", "", "Dump collected metrics into a tarball with the given name")
+	cmd.Flags().StringVar(&tarballName, "tarball-name", "", "Dump collected metrics into a tarball with the given name, requires local indexing")
 	cmd.Flags().SortFlags = false
 	return cmd
 }

--- a/docs/ocp.md
+++ b/docs/ocp.md
@@ -167,7 +167,8 @@ With the help of [networkpolicy](https://kubernetes.io/docs/concepts/services-ne
 
 ## Index
 
-Just like the traditional kube-burner, ocp wrapper also has an indexing functionality which is exposed as `index` subcommand. 
+Just like the traditional kube-burner, ocp wrapper also has an indexing functionality which is exposed as `index` subcommand.
+
 ```console
 $ kube-burner ocp index --help
 If no other indexer is specified, local indexer is used by default
@@ -185,12 +186,15 @@ Flags:
       --user-metadata string       User provided metadata file, in YAML format
   -h, --help                       help for index
 ```
+
 Please refer to [indexing](observability/indexing.md) section for better understanding on the functionality.
 
 ## Reporting mode
+
 This feature is very useful to avoid sending thousands of documents to the configured indexer, as only a few documents will be indexed per benchmark. The metrics profile used by this feature is defined in [metrics-report.yml](https://github.com/cloud-bulldozer/kube-burner/blob/master/cmd/kube-burner/ocp-config/metrics-report.yml)
 
 ## Metrics-profile type
+
 By specifying `--profile-type`, kube-burner can use two different metrics profiles when scraping metrics from prometheus. By default is configured with `both`, meaning that it will use the regular metrics profiles bound to the workload in question and the reporting metrics profile.
 
 While when using the regular profiles ([metrics-aggregated](https://github.com/cloud-bulldozer/kube-burner/blob/master/cmd/kube-burner/ocp-config/metrics-aggregated.yml) or [metrics](https://github.com/cloud-bulldozer/kube-burner/blob/master/cmd/kube-burner/ocp-config/metrics.yml)), kube-burner scrapes and indexes metrics timeseries, the reporting one is a very useful profile to reduce the number of documents sent to the configured indexer. Thanks to the combination of aggregations and instant queries for prometheus metrics, and 4 summaries for pod latency measurements, only a few documents will be indexed per benchmark. This flag makes possible to specify one or both of these profiles indistinctly.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -21,10 +21,6 @@ In this section is described global job configuration, it holds the following pa
 | `measurements`     | List of measurements. Detailed in the [measurements section](/kube-burner/latest/measurements)                            | List          | []          |
 | `indexerConfig`    | Holds the indexer configuration. Detailed in the [indexers section](/kube-burner/latest/observability/indexing)                 | Object        | {}           |
 | `requestTimeout`   | Client-go request timeout                                                                                | Duration      | 15s         |
-| `prometheusURL`    | Prometheus URL endpoint, flag has precedence                                                             | String        | ""         |
-| `bearerToken`      | Bearer token to access the Prometheus endpoint                                                           | String        | ""         |
-| `metricsProfile`   | Path to the metrics profile configuration file                                                           | String         | ""         |
-| `metricsEndpoint`  | Path to the metrics endpoint configuration file containing a list of target endpoints, flag has precedence |  String     | "" |
 | `GC`               | Garbage collect created namespaces                                                                       | Boolean        | false      |
 | `GCMetrics`        | Flag to collect metrics during garbage collection                                                        | Boolean        |      false      |
 | `GCTimeout`               | Garbage collection timeout                                                                       | Duration        | 1h   |

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -236,7 +236,7 @@ func Run(configSpec config.Spec, prometheusClients []*prometheus.Prometheus, ale
 			if globalConfig.IndexerConfig.Type != "" {
 				prometheusClient.ScrapeJobsMetrics(indexer)
 				if globalConfig.IndexerConfig.Type == indexers.LocalIndexer && globalConfig.IndexerConfig.CreateTarball {
-					metrics.CreateTarball(globalConfig.IndexerConfig)
+					metrics.CreateTarball(globalConfig.IndexerConfig, globalConfig.IndexerConfig.TarballName)
 				}
 			}
 		}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -59,16 +59,6 @@ type GlobalConfig struct {
 	Measurements []mtypes.Measurement `yaml:"measurements"`
 	// RequestTimeout of restclient
 	RequestTimeout time.Duration `yaml:"requestTimeout"`
-	// PrometheusURL to interact with
-	PrometheusURL string `yaml:"prometheusURL"`
-	// BearerToken used to access prometheus
-	BearerToken string `yaml:"bearerToken"`
-	// MetricsProfile is the path to the metrics profile configuration
-	MetricsProfile string `yaml:"metricsProfile"`
-	// MetricsEndpoint is path to the metrics endpoint configuration YAML
-	MetricsEndpoint string `yaml:"metricsEndpoint"`
-	// AlertProfile is path to the alert profile
-	AlertProfile string `yaml:"alertProfile"`
 	// GC garbage collect created namespaces
 	GC bool `yaml:"gc" json:"gc"`
 	// WaitWhenFinished Wait for pods to be running when all the jobs are completed

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -32,12 +32,14 @@ type Auth struct {
 type Prometheus struct {
 	Client        *prometheus.Prometheus
 	Endpoint      string
+	profileName   string
 	MetricProfile []metricDefinition
 	Step          time.Duration
 	UUID          string
 	ConfigSpec    config.Spec
 	JobList       []Job
 	metadata      map[string]interface{}
+	embedConfig   bool
 }
 
 type Job struct {

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -56,9 +56,10 @@ func ProcessMetricsScraperConfig(metricsScraperConfig ScraperConfig) Scraper {
 			DecodeMetricsEndpoint(metricsScraperConfig.MetricsEndpoint, &metricsEndpoints)
 		} else {
 			metricsEndpoints = append(metricsEndpoints, prometheus.MetricEndpoint{
-				Endpoint: metricsScraperConfig.URL,
-				Token:    metricsScraperConfig.Token,
-				Profile:  metricsScraperConfig.MetricsProfile,
+				Endpoint:     metricsScraperConfig.URL,
+				Token:        metricsScraperConfig.Token,
+				Profile:      metricsScraperConfig.MetricsProfile,
+				AlertProfile: metricsScraperConfig.AlertProfile,
 			})
 		}
 	}
@@ -79,7 +80,6 @@ func ProcessMetricsScraperConfig(metricsScraperConfig ScraperConfig) Scraper {
 				log.Fatal(err)
 			}
 		}
-		updateParamIfEmpty(&metricsEndpoint.AlertProfile, metricsScraperConfig.AlertProfile)
 		if metricsEndpoint.AlertProfile != "" {
 			if alertM, err = alerting.NewAlertManager(metricsEndpoint.AlertProfile, metricsScraperConfig.ConfigSpec.GlobalConfig.UUID, indexer, p, false); err != nil {
 				log.Fatalf("Error creating alert manager: %s", err)

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -15,11 +15,8 @@
 package metrics
 
 import (
-	"time"
-
 	"github.com/cloud-bulldozer/go-commons/indexers"
 	"github.com/cloud-bulldozer/kube-burner/pkg/alerting"
-	"github.com/cloud-bulldozer/kube-burner/pkg/config"
 	"github.com/cloud-bulldozer/kube-burner/pkg/prometheus"
 	"github.com/cloud-bulldozer/kube-burner/pkg/util"
 	log "github.com/sirupsen/logrus"
@@ -34,7 +31,6 @@ func ProcessMetricsScraperConfig(metricsScraperConfig ScraperConfig) Scraper {
 	var prometheusClients []*prometheus.Prometheus
 	var alertM *alerting.AlertManager
 	var alertMs []*alerting.AlertManager
-	indexerConfig := configSpec.GlobalConfig.IndexerConfig
 	userMetadataContent := make(map[string]interface{})
 	if configSpec.GlobalConfig.IndexerConfig.Type != "" {
 		indexerConfig := configSpec.GlobalConfig.IndexerConfig
@@ -50,94 +46,54 @@ func ProcessMetricsScraperConfig(metricsScraperConfig ScraperConfig) Scraper {
 			log.Fatalf("Error reading provided user metadata: %v", err)
 		}
 	}
+	// Combine rawMetadata with user's provided metadata
+	for k, v := range metricsScraperConfig.RawMetadata {
+		userMetadataContent[k] = v
+	}
 	// When a metric profile or a alert profile is passed we set up metricsEndpoints
 	if metricsScraperConfig.MetricsEndpoint != "" || metricsScraperConfig.MetricsProfile != "" || metricsScraperConfig.AlertProfile != "" {
-		updateParamIfEmpty(&metricsScraperConfig.MetricsEndpoint, configSpec.GlobalConfig.MetricsEndpoint)
-		updateParamIfEmpty(&metricsScraperConfig.URL, configSpec.GlobalConfig.PrometheusURL)
-		if metricsScraperConfig.OcpMetaData == nil {
-			validateMetricsEndpoint(metricsScraperConfig.MetricsEndpoint, metricsScraperConfig.URL)
-		}
+		validateMetricsEndpoint(metricsScraperConfig.MetricsEndpoint, metricsScraperConfig.URL)
 		if metricsScraperConfig.MetricsEndpoint != "" {
 			DecodeMetricsEndpoint(metricsScraperConfig.MetricsEndpoint, &metricsEndpoints)
-			if metricsScraperConfig.OcpMetaData != nil {
-				isClusterPrometheusFound := false
-				for _, metricsEndpoint := range metricsEndpoints {
-					if metricsEndpoint.Endpoint == metricsScraperConfig.URL {
-						isClusterPrometheusFound = true
-						break
-					}
-				}
-				if !isClusterPrometheusFound {
-					metricsEndpoints = append(metricsEndpoints, prometheus.MetricEndpoint{
-						Endpoint: metricsScraperConfig.URL,
-						Token:    metricsScraperConfig.Token,
-					})
-				}
-			}
 		} else {
-			updateParamIfEmpty(&metricsScraperConfig.Token, configSpec.GlobalConfig.BearerToken)
 			metricsEndpoints = append(metricsEndpoints, prometheus.MetricEndpoint{
 				Endpoint: metricsScraperConfig.URL,
 				Token:    metricsScraperConfig.Token,
+				Profile:  metricsScraperConfig.MetricsProfile,
 			})
 		}
 	}
 	for _, metricsEndpoint := range metricsEndpoints {
-		if metricsEndpoint.Profile != "" {
-			configSpec.GlobalConfig.MetricsProfile = metricsEndpoint.Profile
-		} else if metricsScraperConfig.MetricsProfile != "" {
-			configSpec.GlobalConfig.MetricsProfile = metricsScraperConfig.MetricsProfile
-			metricsEndpoint.Profile = metricsScraperConfig.MetricsProfile
-		}
-		metadataContent := map[string]interface{}{}
-		if metricsScraperConfig.ActionIndex {
-			if metricsScraperConfig.OcpMetaData != nil {
-				metadataContent = metricsScraperConfig.OcpMetaData
-			}
-			for k, v := range userMetadataContent {
-				metadataContent[k] = v
-			}
-		}
 		auth := prometheus.Auth{
 			Username:      metricsScraperConfig.Username,
 			Password:      metricsScraperConfig.Password,
-			Token:         metricsScraperConfig.Token,
+			Token:         metricsEndpoint.Token,
 			SkipTLSVerify: metricsScraperConfig.SkipTLSVerify,
 		}
-		p, err := prometheus.NewPrometheusClient(configSpec, metricsEndpoint.Endpoint, auth, metricsScraperConfig.PrometheusStep, metadataContent, false)
+		p, err := prometheus.NewPrometheusClient(configSpec, metricsEndpoint.Endpoint, auth, metricsScraperConfig.PrometheusStep, userMetadataContent, false)
 		if err != nil {
 			log.Fatal(err)
 		}
-		if metricsScraperConfig.ActionIndex {
-			p.JobList = []prometheus.Job{{
-				Start: time.Unix(metricsScraperConfig.StartTime, 0),
-				End:   time.Unix(metricsScraperConfig.EndTime, 0),
-				JobConfig: config.Job{
-					Name: metricsScraperConfig.JobName,
-				},
-			},
+		if metricsEndpoint.Profile != "" {
+			err = p.ReadProfile(metricsEndpoint.Profile)
+			if err != nil {
+				log.Fatal(err)
 			}
-			p.ScrapeJobsMetrics(indexer)
-			if indexerConfig.Type == indexers.LocalIndexer && indexerConfig.CreateTarball {
-				CreateTarball(indexerConfig)
-			}
-		} else {
-			updateParamIfEmpty(&metricsEndpoint.AlertProfile, metricsScraperConfig.AlertProfile)
-			updateParamIfEmpty(&metricsEndpoint.AlertProfile, configSpec.GlobalConfig.AlertProfile)
-			if metricsEndpoint.AlertProfile != "" {
-				if alertM, err = alerting.NewAlertManager(metricsEndpoint.AlertProfile, configSpec.GlobalConfig.UUID, indexer, p, false); err != nil {
-					log.Fatalf("Error creating alert manager: %s", err)
-				}
-			}
-			prometheusClients = append(prometheusClients, p)
-			alertMs = append(alertMs, alertM)
-			alertM = nil
 		}
+		updateParamIfEmpty(&metricsEndpoint.AlertProfile, metricsScraperConfig.AlertProfile)
+		if metricsEndpoint.AlertProfile != "" {
+			if alertM, err = alerting.NewAlertManager(metricsEndpoint.AlertProfile, configSpec.GlobalConfig.UUID, indexer, p, false); err != nil {
+				log.Fatalf("Error creating alert manager: %s", err)
+			}
+		}
+		prometheusClients = append(prometheusClients, p)
+		alertMs = append(alertMs, alertM)
+		alertM = nil
 	}
 	return Scraper{
-		PrometheusClients:   prometheusClients,
-		AlertMs:             alertMs,
-		Indexer:             indexer,
-		UserMetadataContent: userMetadataContent,
+		PrometheusClients: prometheusClients,
+		AlertMs:           alertMs,
+		Indexer:           indexer,
+		Metadata:          userMetadataContent,
 	}
 }

--- a/pkg/util/metrics/tarball.go
+++ b/pkg/util/metrics/tarball.go
@@ -29,8 +29,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func CreateTarball(indexerConfig indexers.IndexerConfig) error {
-	tarball, err := os.Create(fmt.Sprintf(indexerConfig.TarballName))
+func CreateTarball(indexerConfig indexers.IndexerConfig, tarballName string) error {
+	tarball, err := os.Create(tarballName)
 	if err != nil {
 		return fmt.Errorf("Could not create tarball file: %v", err)
 	}

--- a/pkg/util/metrics/types.go
+++ b/pkg/util/metrics/types.go
@@ -35,18 +35,14 @@ type ScraperConfig struct {
 	URL             string
 	Token           string
 	Username        string
-	StartTime       int64
-	EndTime         int64
-	JobName         string
-	ActionIndex     bool
 	UserMetaData    string
-	OcpMetaData     map[string]interface{}
+	RawMetadata     map[string]interface{}
 }
 
 // ScraperResponse holds parsed data related to scraper and target indexer
 type Scraper struct {
-	PrometheusClients   []*prometheus.Prometheus
-	AlertMs             []*alerting.AlertManager
-	Indexer             *indexers.Indexer
-	UserMetadataContent map[string]interface{}
+	PrometheusClients []*prometheus.Prometheus
+	AlertMs           []*alerting.AlertManager
+	Indexer           *indexers.Indexer
+	Metadata          map[string]interface{}
 }

--- a/pkg/util/metrics/utils.go
+++ b/pkg/util/metrics/utils.go
@@ -24,13 +24,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Updates parameter in place with new value if its is empty
-func updateParamIfEmpty(oldValue *string, newValue string) {
-	if *oldValue == "" {
-		*oldValue = newValue
-	}
-}
-
 // Performs the validity check of metrics endpoint and prometheus url
 func validateMetricsEndpoint(metricsEndpoint string, prometheusURL string) {
 	if (metricsEndpoint != "" && prometheusURL != "") || (metricsEndpoint == "" && prometheusURL == "") {

--- a/pkg/workloads/helpers.go
+++ b/pkg/workloads/helpers.go
@@ -231,9 +231,6 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 	}
 	for _, metricsEndpoint := range metricsEndpoints {
 		// Updating the prometheus endpoint actually being used in spec.
-		configSpec.GlobalConfig.PrometheusURL = metricsEndpoint.Endpoint
-		configSpec.GlobalConfig.MetricsProfile = metricsEndpoint.Profile
-		configSpec.GlobalConfig.AlertProfile = metricsEndpoint.AlertProfile
 		auth := prometheus.Auth{
 			Token:         metricsEndpoint.Token,
 			SkipTLSVerify: true,
@@ -242,8 +239,12 @@ func (wh *WorkloadHelper) run(workload, metricsProfile string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if wh.alerting && configSpec.GlobalConfig.AlertProfile != "" {
-			alertM, err = alerting.NewAlertManager(configSpec.GlobalConfig.AlertProfile, wh.Metadata.UUID, indexer, p, embedConfig)
+		p.ReadProfile(metricsEndpoint.Profile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if wh.alerting && metricsEndpoint.AlertProfile != "" {
+			alertM, err = alerting.NewAlertManager(metricsEndpoint.AlertProfile, wh.Metadata.UUID, indexer, p, embedConfig)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/workloads/index.go
+++ b/pkg/workloads/index.go
@@ -109,7 +109,7 @@ func NewIndex(metricsEndpoint *string, metadata *BenchmarkMetadata, ocpMetaAgent
 					rc = 1
 				}
 			}
-			if tarballName != "" {
+			if configSpec.GlobalConfig.IndexerConfig.Type == indexers.LocalIndexer && tarballName != "" {
 				if err := metrics.CreateTarball(configSpec.GlobalConfig.IndexerConfig, tarballName); err != nil {
 					log.Fatal(err)
 				}
@@ -123,7 +123,7 @@ func NewIndex(metricsEndpoint *string, metadata *BenchmarkMetadata, ocpMetaAgent
 	cmd.Flags().Int64Var(&end, "end", time.Now().Unix(), "Epoch end time")
 	cmd.Flags().StringVar(&jobName, "job-name", "kube-burner-ocp-indexing", "Indexing job name")
 	cmd.Flags().StringVar(&userMetadata, "user-metadata", "", "User provided metadata file, in YAML format")
-	cmd.Flags().StringVar(&tarballName, "tarball-name", "", "Dump collected metrics into a tarball with the given name")
+	cmd.Flags().StringVar(&tarballName, "tarball-name", "", "Dump collected metrics into a tarball with the given name, requires local indexing")
 	cmd.Flags().SortFlags = false
 	return cmd
 }

--- a/pkg/workloads/index.go
+++ b/pkg/workloads/index.go
@@ -15,11 +15,13 @@
 package workloads
 
 import (
-	"encoding/json"
+	"os"
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
 	ocpmetadata "github.com/cloud-bulldozer/go-commons/ocp-metadata"
+	"github.com/cloud-bulldozer/kube-burner/pkg/config"
+	"github.com/cloud-bulldozer/kube-burner/pkg/prometheus"
 	"github.com/cloud-bulldozer/kube-burner/pkg/util/metrics"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -32,29 +34,23 @@ func NewIndex(metricsEndpoint *string, metadata *BenchmarkMetadata, ocpMetaAgent
 	var userMetadata, metricsDirectory string
 	var prometheusStep time.Duration
 	var uuid string
+	var rc int
+	var prometheusURL, prometheusToken string
+	var tarballName string
 	cmd := &cobra.Command{
 		Use:          "index",
 		Short:        "Runs index sub-command",
 		Long:         "If no other indexer is specified, local indexer is used by default",
 		SilenceUsage: true,
-		PreRun: func(cmd *cobra.Command, args []string) {
-			uuid, _ = cmd.InheritedFlags().GetString("uuid")
-		},
 		PostRun: func(cmd *cobra.Command, args []string) {
 			log.Info("👋 Exiting kube-burner ", uuid)
+			os.Exit(rc)
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			uuid, _ = cmd.Flags().GetString("uuid")
 			clusterMetadata, err := ocpMetaAgent.GetClusterMetadata()
 			if err != nil {
 				log.Fatal("Error obtaining clusterMetadata: ", err.Error())
-			}
-			ocpMetadata := make(map[string]interface{})
-			jsonData, err := json.Marshal(clusterMetadata)
-			if err != nil {
-				log.Fatal("Error getting clusterMetadata json: ", err.Error())
-			}
-			if err := json.Unmarshal(jsonData, &ocpMetadata); err != nil {
-				log.Fatal("Errar unmarshalling clusterMetadata: ", err.Error())
 			}
 			esServer, _ := cmd.Flags().GetString("es-server")
 			esIndex, _ := cmd.Flags().GetString("es-index")
@@ -74,11 +70,22 @@ func NewIndex(metricsEndpoint *string, metadata *BenchmarkMetadata, ocpMetaAgent
 					MetricsDirectory: metricsDirectory,
 				}
 			}
-			prometheusURL, prometheusToken, err := ocpMetaAgent.GetPrometheus()
-			if err != nil {
-				log.Fatal("Error obtaining prometheus information from cluster: ", err.Error())
+			// When metricsEndpoint is specified, don't fetch any prometheus token
+			if *metricsEndpoint == "" {
+				prometheusURL, prometheusToken, err = ocpMetaAgent.GetPrometheus()
+				if err != nil {
+					log.Fatal("Error obtaining prometheus information from cluster: ", err.Error())
+				}
 			}
-			scraperOutput := metrics.ProcessMetricsScraperConfig(metrics.ScraperConfig{
+			metadata := map[string]interface{}{
+				"platform":        clusterMetadata.Platform,
+				"ocpVersion":      clusterMetadata.OCPVersion,
+				"ocpMajorVersion": clusterMetadata.OCPMajorVersion,
+				"k8sVersion":      clusterMetadata.K8SVersion,
+				"totalNodes":      clusterMetadata.TotalNodes,
+				"sdnType":         clusterMetadata.SDNType,
+			}
+			metricsScraper := metrics.ProcessMetricsScraperConfig(metrics.ScraperConfig{
 				ConfigSpec:      configSpec,
 				PrometheusStep:  prometheusStep,
 				MetricsEndpoint: *metricsEndpoint,
@@ -86,14 +93,27 @@ func NewIndex(metricsEndpoint *string, metadata *BenchmarkMetadata, ocpMetaAgent
 				SkipTLSVerify:   true,
 				URL:             prometheusURL,
 				Token:           prometheusToken,
-				StartTime:       start,
-				EndTime:         end,
-				JobName:         jobName,
-				ActionIndex:     true,
 				UserMetaData:    userMetadata,
-				OcpMetaData:     ocpMetadata,
+				RawMetadata:     metadata,
 			})
-			IndexMetadata(scraperOutput.Indexer, *metadata)
+			for _, prometheusClients := range metricsScraper.PrometheusClients {
+				prometheusJob := prometheus.Job{
+					Start: time.Unix(start, 0),
+					End:   time.Unix(end, 0),
+					JobConfig: config.Job{
+						Name: jobName,
+					},
+				}
+				prometheusClients.JobList = append(prometheusClients.JobList, prometheusJob)
+				if prometheusClients.ScrapeJobsMetrics(metricsScraper.Indexer) != nil {
+					rc = 1
+				}
+			}
+			if tarballName != "" {
+				if err := metrics.CreateTarball(configSpec.GlobalConfig.IndexerConfig, tarballName); err != nil {
+					log.Fatal(err)
+				}
+			}
 		},
 	}
 	cmd.Flags().StringVar(&metricsProfile, "metrics-profile", "metrics.yml", "Metrics profile file")
@@ -103,6 +123,7 @@ func NewIndex(metricsEndpoint *string, metadata *BenchmarkMetadata, ocpMetaAgent
 	cmd.Flags().Int64Var(&end, "end", time.Now().Unix(), "Epoch end time")
 	cmd.Flags().StringVar(&jobName, "job-name", "kube-burner-ocp-indexing", "Indexing job name")
 	cmd.Flags().StringVar(&userMetadata, "user-metadata", "", "User provided metadata file, in YAML format")
+	cmd.Flags().StringVar(&tarballName, "tarball-name", "", "Dump collected metrics into a tarball with the given name")
 	cmd.Flags().SortFlags = false
 	return cmd
 }


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Simplifying the indexing logic, specially in util/metrics/metrics.go. `ScraperConfig` has now fewer fields, `actionIndex` is not required anymore, and standalone `index` subcommands take care of calling ScrapeJobsMetrics() by themselves rather than calling a function for everything like ProcessMetricsScraperConfig)() was

Also getting rid of these stale configuration parameters.

- prometheusUrl
- bearerToken
- metricsProfile
- metricsEndpoint

These config parameters are not being used and they increase the complexity the code quite a bit (they were added because it request of the arcaflow team, however they are not using them either)

--- 

Adding tarball creation support to `ocp index` and prevent indexing benchmark metadata in this subcommand, as its not actually required here.

#498 has been fixed as part of this PR

## Related Tickets & Documents

- Related Issue #
- Closes #498

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
