### PR TITLE
Add network-policy workload

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -39,35 +39,36 @@ kube-burner connects k8s clusters using the following methods in this order:
 
 This section contains the list of jobs `kube-burner` will execute. Each job can hold the following parameters.
 
-| Option               | Description                                                                      | Type    | Default |
-|----------------------|----------------------------------------------------------------------------------|---------|----------|
-| `name`                 | Job name                                                                         | String  | ""      |
-| `jobType`              | Type of job to execute. More details at [job types](#job-types)                  | string  | create  |
-| `jobIterations`        | How many times to execute the job                                                | Integer | 0       |
-| `namespace`            | Namespace base name to use                                                       | String  | ""      |
-| `namespacedIterations` | Whether to create a namespace per job iteration                                  | Boolean | true    |
-| `iterationsPerNamespace` | The maximum number of `jobIterations` to create in a single namespace. Important for node-density workloads that create Services.                                  | Integer | 1    |
-| `cleanup`              | Cleanup clean up old namespaces                                                  | Boolean | true    |
-| `podWait`              | Wait for all pods to be running before moving forward to the next job iteration  | Boolean | false   |
-| `waitWhenFinished`     | Wait for all pods to be running when all iterations are completed                | Boolean | true    |
-| `maxWaitTimeout`       | Maximum wait timeout per namespace                                               | Duration| 4h     |
-| `jobIterationDelay`    | How long to wait between each job iteration. This is also the wait interval between each delete operation | Duration| 0s      |
-| `jobPause`             | How long to pause after finishing the job                                        | Duration| 0s      |
-| `qps`                  | Limit object creation queries per second                                         | Integer | 0       |
-| `burst`                | Maximum burst for throttle                                                       | Integer | 0       |
-| `objects`              | List of objects the job will create. Detailed on the [objects section](#objects) | List    | []      |
-| `verifyObjects`        | Verify object count after running each job                                       | Boolean | true    |
-| `errorOnVerify`        | Set RC to 1 when objects verification fails                                      | Boolean | true    |
-| `skipIndexing`         | Skip metric indexing on this job                                                 | Boolean | false   |
-| `preLoadImages`        | Kube-burner will create a DS before triggering the job to pull all the images of the job   | true    |
-| `preLoadPeriod`        | How long to wait for the preload daemonset                                       | Duration| 1m     |
-| `preloadNodeLabels`    | Add node selector labels for the resources created in preload stage              | Object  | {} |
-| `namespaceLabels`      | Add custom labels to the namespaces created by kube-burner                       | Object  | {} |
-| `churn`                | Churn the workload. Only supports namespace based workloads                      | Boolean | false |
-| `churnPercent`         | Percentage of the jobIterations to churn each period                             | Integer | 10 |
-| `churnDuration`        | Length of time that the job is churned for                                       | Duration| 1h |
-| `churnDelay`           | Length of time to wait between each churn period                                 | Duration| 5m |
-| `churnDeletionStrategy` | Churn deletion strategy to apply. Either "default" or "gvr" (i.e new logic) | String | default
+| Option                   | Description                                                                                                                       | Type     | Default |
+|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------|----------|---------|
+| `name`                   | Job name                                                                                                                          | String   | ""      |
+| `jobType`                | Type of job to execute. More details at [job types](#job-types)                                                                   | string   | create  |
+| `jobIterations`          | How many times to execute the job                                                                                                 | Integer  | 0       |
+| `namespace`              | Namespace base name to use                                                                                                        | String   | ""      |
+| `namespacedIterations`   | Whether to create a namespace per job iteration                                                                                   | Boolean  | true    |
+| `iterationsPerNamespace` | The maximum number of `jobIterations` to create in a single namespace. Important for node-density workloads that create Services. | Integer  | 1       |
+| `cleanup`                | Cleanup clean up old namespaces                                                                                                   | Boolean  | true    |
+| `podWait`                | Wait for all pods to be running before moving forward to the next job iteration                                                   | Boolean  | false   |
+| `waitWhenFinished`       | Wait for all pods to be running when all iterations are completed                                                                 | Boolean  | true    |
+| `maxWaitTimeout`         | Maximum wait timeout per namespace                                                                                                | Duration | 4h      |
+| `jobIterationDelay`      | How long to wait between each job iteration. This is also the wait interval between each delete operation                         | Duration | 0s      |
+| `jobPause`               | How long to pause after finishing the job                                                                                         | Duration | 0s      |
+| `beforeCleanup`          | Allows to run a bash script before the workload is deleted                                                                        | String   | ""      |
+| `qps`                    | Limit object creation queries per second                                                                                          | Integer  | 0       |
+| `burst`                  | Maximum burst for throttle                                                                                                        | Integer  | 0       |
+| `objects`                | List of objects the job will create. Detailed on the [objects section](#objects)                                                  | List     | []      |
+| `verifyObjects`          | Verify object count after running each job                                                                                        | Boolean  | true    |
+| `errorOnVerify`          | Set RC to 1 when objects verification fails                                                                                       | Boolean  | true    |
+| `skipIndexing`           | Skip metric indexing on this job                                                                                                  | Boolean  | false   |
+| `preLoadImages`          | Kube-burner will create a DS before triggering the job to pull all the images of the job                                          | true     |         |
+| `preLoadPeriod`          | How long to wait for the preload daemonset                                                                                        | Duration | 1m      |
+| `preloadNodeLabels`      | Add node selector labels for the resources created in preload stage                                                               | Object   | {}      |
+| `namespaceLabels`        | Add custom labels to the namespaces created by kube-burner                                                                        | Object   | {}      |
+| `churn`                  | Churn the workload. Only supports namespace based workloads                                                                       | Boolean  | false   |
+| `churnPercent`           | Percentage of the jobIterations to churn each period                                                                              | Integer  | 10      |
+| `churnDuration`          | Length of time that the job is churned for                                                                                        | Duration | 1h      |
+| `churnDelay`             | Length of time to wait between each churn period                                                                                  | Duration | 5m      |
+| `churnDeletionStrategy`  | Churn deletion strategy to apply. Either "default" or "gvr" (i.e new logic)                                                       | String   | default |
 
 Our configuration files strictly follow YAML syntax. To clarify on List and Object types usage, they are nothing but the [`Lists and Dictionaries`](https://gettaurus.org/docs/YAMLTutorial/#Lists-and-Dictionaries) in YAML syntax.
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/time v0.1.0
+	gonum.org/v1/gonum v0.13.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2

--- a/go.sum
+++ b/go.sum
@@ -863,6 +863,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gonum.org/v1/gonum v0.13.0 h1:a0T3bh+7fhRyqeNbiC3qVHYmkiQgit3wnNan/2c0HMM=
+gonum.org/v1/gonum v0.13.0/go.mod h1:/WPYRckkfWrhWefxyYTfrTtQR0KH4iyHNuzxqXAKyAU=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -102,6 +102,8 @@ type Job struct {
 	JobIterationDelay time.Duration `yaml:"jobIterationDelay" json:"jobIterationDelay,omitempty"`
 	// JobPause how much time to pause after finishing the job
 	JobPause time.Duration `yaml:"jobPause" json:"jobPause,omitempty"`
+	// BeforeCleanup allows to run a bash script before the workload is deleted.
+	BeforeCleanup string `yaml:"beforeCleanup" json:"beforeCleanup,omitempty"`
 	// Name job name
 	Name string `yaml:"name" json:"name,omitempty"`
 	// Objects list of objects


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Create network-policy scale testing framework and 2 profiles for
openshift and ovn-kubernetes.

kube-burner modification: add ShutdownCondition to jobConfig. This
allows to set up a command that should exit before the workload
can be deleted. It is used by the network policy workload, since network
policy doesn't have a status, and extra means to track when the config
is applied are needed.
Add Binomial, IndexToCombination and GetSubnet24 functions for
templating, since they are needed to generate complex network policy
configs.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [?] If it is a core feature, I have added thorough tests.
