### PR TITLE
Set more accurate 70m cpu request on cluster-density builds for better scheduling

### DIFF
--- a/cmd/kube-burner/ocp-config/cluster-density-v2/build.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density-v2/build.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   resources:
     requests:
-      cpu: 20m
+      cpu: 70m
       memory: "10Mi"
   nodeSelector:
     node-role.kubernetes.io/worker: ""

--- a/cmd/kube-burner/ocp-config/cluster-density/build.yml
+++ b/cmd/kube-burner/ocp-config/cluster-density/build.yml
@@ -4,6 +4,10 @@ apiVersion: build.openshift.io/v1
 metadata:
   name: {{.JobName}}-{{.Replica}}
 spec:
+  resources:
+    requests:
+      cpu: 70m
+      memory: "10Mi"
   nodeSelector:
     node-role.kubernetes.io/worker: ""
   serviceAccount: builder

--- a/examples/workloads/cluster-density/templates/build.yml
+++ b/examples/workloads/cluster-density/templates/build.yml
@@ -4,6 +4,10 @@ apiVersion: build.openshift.io/v1
 metadata:
   name: {{.JobName}}-{{.Replica}}
 spec:
+  resources:
+    requests:
+      cpu: 70m
+      memory: "10Mi"
   nodeSelector:
     node-role.kubernetes.io/worker: ""
   serviceAccount: builder


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Build pods created by cluster density workloads actually use more like 70m CPU at peak. Adjusting this CPU request accordingly will help distribute the builds more evenly across the cluster. Unevenly distributed builds are a leading factor of higher pod latencies.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.