### PR TITLE
Measure sub command to collect measurements in past

### DIFF
--- a/cmd/kube-burner/ocp.go
+++ b/cmd/kube-burner/ocp.go
@@ -88,7 +88,7 @@ func openShiftCmd() *cobra.Command {
 		workloads.NewNodeDensity(&wh),
 		workloads.NewNodeDensityHeavy(&wh),
 		workloads.NewNodeDensityCNI(&wh),
-		workloads.NewIndex(&wh.MetricsEndpoint, &wh.Metadata, &wh.OcpMetaAgent),
+		workloads.NewIndex(&wh.MetricsEndpoint, &wh.OcpMetaAgent),
 		workloads.NewPVCDensity(&wh),
 	)
 	return ocpCmd

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,7 +7,7 @@ given rate. The actions taken by this tool are highly customizable and their ava
 $ kube-burner help
 Kube-burner 🔥
 
-Tool aimed at stressing a Kubernetes cluster by creating or deleting lots of objects.
+Tool aimed at stressing a kubernetes cluster by creating or deleting lots of objects.
 
 Usage:
   kube-burner [command]
@@ -20,11 +20,13 @@ Available Commands:
   import       Import metrics tarball
   index        Index kube-burner metrics
   init         Launch benchmark
+  measure      Take measurements for a given set of resources without running workload
+  ocp          OpenShift wrapper
   version      Print the version number of kube-burner
 
 Flags:
-  -h, --help   help for kube-burner
-  --log-level string   Allowed values: debug, info, warn, error, fatal (default "info")
+  -h, --help               help for kube-burner
+      --log-level string   Allowed values: debug, info, warn, error, fatal (default "info")
 
 Use "kube-burner [command] --help" for more information about a command.
 ```
@@ -90,6 +92,16 @@ This subcommand can be used to collect and index the metrics from a given time r
 
 - `start`: Epoch start time. Defaults to one hour before the current time.
 - `end`: Epoch end time. Defaults to the current time.
+
+## Measure
+This subcommand can be used to collect measurements for a given set of resources which were part of a workload ran in past and are still present on the cluster (i.e only supports podLatency as of today).
+We can specify a list of namespaces and selector labels as input.
+
+- `namespaces`: comma-separated list of namespaces provided as a string input. This is optional, by default all namespaces are considered.
+- `selector`: comma-separated list of selector labels in the format key1=value1,key2=value2. This is optional, by default no labels will be used for filtering.
+
+!!! Note
+    This subcommand should only be used to fetch measurements of a workload ran in the past. Also those resources should be active on the cluster. For present cases, please refer to the alternate options in this tool.
 
 ## Check alerts
 

--- a/docs/measurements.md
+++ b/docs/measurements.md
@@ -114,6 +114,26 @@ WARN[2020-12-15 12:37:08] P99 Ready latency (2929ms) higher than configured thre
 
 In case of not meeting any of the configured thresholds, like the example above, **kube-burner return code will be 1**.
 
+### Measure subcommand CLI example
+Measure subcommand example with relevant options. It is used to fetch measurements on top of resources that were a part of workload ran in past.
+```
+kube-burner measure --uuid=vchalla --namespaces=cluster-density-v2-0,cluster-density-v2-1,cluster-density-v2-2,cluster-density-v2-3,cluster-density-v2-4 --selector=kube-burner-job=cluster-density-v2 
+time="2023-11-19 17:46:05" level=info msg="📁 Creating indexer: elastic" file="kube-burner.go:226"
+time="2023-11-19 17:46:05" level=info msg="map[kube-burner-job:cluster-density-v2]" file="kube-burner.go:247"
+time="2023-11-19 17:46:05" level=info msg="📈 Registered measurement: podLatency" file="factory.go:85"
+time="2023-11-19 17:46:06" level=info msg="Stopping measurement: podLatency" file="factory.go:118"
+time="2023-11-19 17:46:06" level=info msg="Evaluating latency thresholds" file="metrics.go:60"
+time="2023-11-19 17:46:06" level=info msg="Indexing pod latency data for job: kube-burner-measure" file="pod_latency.go:245"
+time="2023-11-19 17:46:07" level=info msg="Indexing finished in 417ms: created=4" file="pod_latency.go:262"
+time="2023-11-19 17:46:08" level=info msg="Indexing finished in 1.32s: created=50" file="pod_latency.go:262"
+time="2023-11-19 17:46:08" level=info msg="kube-burner-measure: PodScheduled 50th: 0 99th: 0 max: 0 avg: 0" file="pod_latency.go:233"
+time="2023-11-19 17:46:08" level=info msg="kube-burner-measure: ContainersReady 50th: 9000 99th: 18000 max: 18000 avg: 10680" file="pod_latency.go:233"
+time="2023-11-19 17:46:08" level=info msg="kube-burner-measure: Initialized 50th: 0 99th: 0 max: 0 avg: 0" file="pod_latency.go:233"
+time="2023-11-19 17:46:08" level=info msg="kube-burner-measure: Ready 50th: 9000 99th: 18000 max: 18000 avg: 10680" file="pod_latency.go:233"
+time="2023-11-19 17:46:08" level=info msg="Pod latencies error rate was: 0.00" file="pod_latency.go:236"
+time="2023-11-19 17:46:08" level=info msg="👋 Exiting kube-burner vchalla" file="kube-burner.go:209"
+```
+
 ## pprof collection
 
 This measurement can be used to collect Golang profiling information from processes running in pods from the cluster. To do so, kube-burner connects to pods labeled with `labelSelector` and running in `namespace`. This measurement uses an implementation similar to `kubectl exec`, and as soon as it connects to one pod it executes the command `curl <pprofURL>` to get the pprof data. pprof files are collected in a regular basis configured by the parameter `pprofInterval`, the collected pprof files are downloaded from the pods to the local directory configured by the parameter `pprofDirectory` which by default is `pprof`.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,9 +123,6 @@ func Parse(uuid string, f io.Reader) (Spec, error) {
 	if err = yamlDec.Decode(&configSpec); err != nil {
 		return configSpec, fmt.Errorf("error decoding configuration file: %s", err)
 	}
-	if len(configSpec.Jobs) <= 0 {
-		return configSpec, fmt.Errorf("no jobs found in the configuration file")
-	}
 	if err := jobIsDuped(); err != nil {
 		return configSpec, err
 	}

--- a/pkg/measurements/factory.go
+++ b/pkg/measurements/factory.go
@@ -40,6 +40,7 @@ type measurementFactory struct {
 type measurement interface {
 	start(*sync.WaitGroup)
 	stop() error
+	collect(*sync.WaitGroup)
 	setConfig(types.Measurement) error
 }
 
@@ -96,6 +97,15 @@ func Start() {
 	for _, measurement := range factory.createFuncs {
 		wg.Add(1)
 		go measurement.start(&wg)
+	}
+	wg.Wait()
+}
+
+func Collect() {
+	var wg sync.WaitGroup
+	for _, measurement := range factory.createFuncs {
+		wg.Add(1)
+		go measurement.collect(&wg)
 	}
 	wg.Wait()
 }

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -15,6 +15,7 @@
 package measurements
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sort"
@@ -28,6 +29,8 @@ import (
 	"github.com/cloud-bulldozer/kube-burner/pkg/measurements/types"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
@@ -154,10 +157,61 @@ func (p *podLatency) start(measurementWg *sync.WaitGroup) {
 	}
 }
 
+// collects pod measurements triggered in the past
+func (p *podLatency) collect(measurementWg *sync.WaitGroup) {
+	defer measurementWg.Done()
+	var pods []corev1.Pod
+	labelSelector := labels.SelectorFromSet(factory.jobConfig.NamespaceLabels)
+	options := metav1.ListOptions{
+		LabelSelector: labelSelector.String(),
+	}
+	namespaces := strings.Split(factory.jobConfig.Namespace, ",")
+	for _, namespace := range namespaces {
+		podList, err := factory.clientSet.CoreV1().Pods(namespace).List(context.TODO(), options)
+		if err != nil {
+			log.Errorf("error listing pods in namespace %s: %v", namespace, err)
+		}
+		pods = append(pods, podList.Items...)
+	}
+	p.metrics = make(map[string]podMetric)
+	for _, pod := range pods {
+		var scheduled, initialized, containersReady, podReady time.Time
+		for _, c := range pod.Status.Conditions {
+			switch c.Type {
+			case corev1.PodScheduled:
+				scheduled = c.LastTransitionTime.Time.UTC()
+			case corev1.PodInitialized:
+				initialized = c.LastTransitionTime.Time.UTC()
+			case corev1.ContainersReady:
+				containersReady = c.LastTransitionTime.Time.UTC()
+			case corev1.PodReady:
+				podReady = c.LastTransitionTime.Time.UTC()
+			}
+		}
+		p.metrics[string(pod.UID)] = podMetric{
+			Timestamp:       pod.Status.StartTime.Time.UTC(),
+			Namespace:       pod.Namespace,
+			Name:            pod.Name,
+			MetricName:      podLatencyMeasurement,
+			NodeName:        pod.Spec.NodeName,
+			UUID:            globalCfg.UUID,
+			JobConfig:       *factory.jobConfig,
+			JobName:         factory.jobConfig.Name,
+			Metadata:        factory.metadata,
+			scheduled:       scheduled,
+			initialized:     initialized,
+			containersReady: containersReady,
+			podReady:        podReady,
+		}
+	}
+}
+
 // Stop stops podLatency measurement
 func (p *podLatency) stop() error {
 	var err error
-	p.watcher.StopWatcher()
+	if p.watcher != nil {
+		p.watcher.StopWatcher()
+	}
 	errorRate := p.normalizeMetrics()
 	if errorRate > 10.00 {
 		log.Error("Latency errors beyond 10%. Hence invalidating the results")
@@ -171,7 +225,6 @@ func (p *podLatency) stop() error {
 		if factory.jobConfig.SkipIndexing {
 			log.Infof("Skipping pod latency data indexing in job: %s", factory.jobConfig.Name)
 		} else {
-			log.Infof("Indexing pod latency data for job: %s", factory.jobConfig.Name)
 			p.index()
 		}
 	}

--- a/pkg/measurements/pprof.go
+++ b/pkg/measurements/pprof.go
@@ -179,6 +179,10 @@ func (p *pprof) getPProf(wg *sync.WaitGroup, first bool) {
 	wg.Wait()
 }
 
+func (p *pprof) collect(measurementWg *sync.WaitGroup) {
+	defer measurementWg.Done()
+}
+
 func (p *pprof) stop() error {
 	p.stopChannel <- true
 	return nil

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -365,6 +365,10 @@ func setConfigDefaults(config *rest.Config) {
 	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: codecs}
 }
 
+func (p *vmiLatency) collect(measurementWg *sync.WaitGroup) {
+	defer measurementWg.Done()
+}
+
 // Stop stops vmiLatency measurement
 func (p *vmiLatency) stop() error {
 	p.vmWatcher.StopWatcher()

--- a/pkg/workloads/index.go
+++ b/pkg/workloads/index.go
@@ -28,7 +28,7 @@ import (
 )
 
 // NewIndex orchestrates indexing for ocp wrapper
-func NewIndex(metricsEndpoint *string, metadata *BenchmarkMetadata, ocpMetaAgent *ocpmetadata.Metadata) *cobra.Command {
+func NewIndex(metricsEndpoint *string, ocpMetaAgent *ocpmetadata.Metadata) *cobra.Command {
 	var metricsProfile, jobName string
 	var start, end int64
 	var userMetadata, metricsDirectory string


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [x] Documentation Update

## Description

Introduced `measure` sub command to collection measurements in past.

## Related Tickets & Documents

- Related Issue # https://github.com/cloud-bulldozer/kube-burner/issues/138
- Closes # https://github.com/cloud-bulldozer/kube-burner/issues/138

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
Tested in local environment. Example config:
```
---
global:
  indexerConfig:
    esServers: ["{{.ES_SERVER}}"]
    insecureSkipVerify: true
    defaultIndex: {{.ES_INDEX}}
    type: elastic
  measurements:
    - name: podLatency
      thresholds:
        - conditionType: Ready
          metric: P99
          threshold: 25s
```
Command to trigger:
```
kube-burner measure --uuid=vchalla --namespaces=cluster-density-v2-0,cluster-density-v2-1,cluster-density-v2-2,cluster-density-v2-3,cluster-density-v2-4 --labels=kube-burner-job=cluster-density-v2 
time="2023-11-12 21:22:09" level=info msg="📁 Creating indexer: elastic" file="kube-burner.go:226"
time="2023-11-12 21:22:10" level=info msg="📈 Registered measurement: podLatency" file="factory.go:85"
time="2023-11-12 21:22:12" level=info msg="Stopping measurement: podLatency" file="factory.go:118"
time="2023-11-12 21:22:12" level=info msg="Evaluating latency thresholds" file="metrics.go:60"
time="2023-11-12 21:22:12" level=info msg="Indexing pod latency data for job: measure" file="pod_latency.go:245"
time="2023-11-12 21:22:13" level=info msg="Indexing finished in 385ms: created=4" file="pod_latency.go:262"
time="2023-11-12 21:22:15" level=info msg="Indexing finished in 1.661s: created=50" file="pod_latency.go:262"
time="2023-11-12 21:22:15" level=info msg="measure: PodScheduled 50th: 0 99th: 0 max: 0 avg: 0" file="pod_latency.go:233"
time="2023-11-12 21:22:15" level=info msg="measure: ContainersReady 50th: 9000 99th: 19000 max: 19000 avg: 11220" file="pod_latency.go:233"
time="2023-11-12 21:22:15" level=info msg="measure: Initialized 50th: 0 99th: 0 max: 0 avg: 0" file="pod_latency.go:233"
time="2023-11-12 21:22:15" level=info msg="measure: Ready 50th: 9000 99th: 19000 max: 19000 avg: 11220" file="pod_latency.go:233"
time="2023-11-12 21:22:15" level=info msg="Pod latencies error rate was: 0.00" file="pod_latency.go:236"
time="2023-11-12 21:22:15" level=info msg="👋 Exiting kube-burner vchalla" file="kube-burner.go:209"
```