### PR TITLE
Fix unsafe access to labels map to avoid a panic

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -17,7 +17,6 @@ package burner
 import (
 	"context"
 	"embed"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -239,7 +238,6 @@ func (ex *Executor) replicaHandler(labels map[string]string, obj object, ns stri
 			newObject.SetLabels(copiedLabels)
 			setMetadataLabels(newObject, copiedLabels)
 
-			json.Marshal(newObject.Object)
 			// replicaWg is necessary because we want to wait for all replicas
 			// to be created before running any other action such as verify objects,
 			// wait for ready, etc. Without this wait group, running for example,

--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -206,7 +206,7 @@ func (ex *Executor) replicaHandler(labels map[string]string, obj object, ns stri
 	var wg sync.WaitGroup
 
 	for r := 1; r <= obj.Replicas; r++ {
-		// make a copy of the copiedLabels map
+		// make a copy of the labels map for each goroutine to prevent panic from concurrent read and write
 		copiedLabels := make(map[string]string)
 		for k, v := range labels {
 			copiedLabels[k] = v


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Make a per-goroutine copy of the `label` map to avoid concurrent read/writes to it.

## Related Tickets & Documents

- Closes #534 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
