### PR TITLE
config: bump RequestTimeout to 60s by default

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -20,7 +20,7 @@ In this section is described global job configuration, it holds the following pa
 |------------------|----------------------------------------------------------------------------------------------------------|----------------|--------------|
 | `measurements`     | List of measurements. Detailed in the [measurements section](/kube-burner/latest/measurements)                            | List          | []          |
 | `indexerConfig`    | Holds the indexer configuration. Detailed in the [indexers section](/kube-burner/latest/observability/indexing)                 | Object        | {}           |
-| `requestTimeout`   | Client-go request timeout                                                                                | Duration      | 15s         |
+| `requestTimeout`   | Client-go request timeout                                                                                | Duration      | 60s         |
 | `gc`               | Garbage collect created namespaces                                                                       | Boolean        | false      |
 | `gcMetrics`        | Flag to collect metrics during garbage collection                                                        | Boolean        |      false      |
 | `gcTimeout`               | Garbage collection timeout                                                                       | Duration        | 1h   |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,7 +45,7 @@ var configSpec = Spec{
 		GC:             false,
 		GCMetrics:      false,
 		GCTimeout:      1 * time.Hour,
-		RequestTimeout: 15 * time.Second,
+		RequestTimeout: 60 * time.Second,
 		Measurements:   []mtypes.Measurement{},
 		IndexerConfig: indexers.IndexerConfig{
 			InsecureSkipVerify: false,


### PR DESCRIPTION
In very large clusters or with large scale tests (100,000 plus pods) requests can take more than 15 seconds to list all objects. Bump the timeout to accommodate lots of objects.