### PR TITLE
precreate-namespace

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -110,6 +110,14 @@ func (ex *Executor) RunCreateJob(ctx context.Context, iterationStart, iterationE
 	percent := 1
 	var namespacesCreated = make(map[string]bool)
 	var namespacesWaited = make(map[string]bool)
+
+	// Pre-create namespaces if required
+	if ex.Job.PreCreateNamespaces {
+		if err := ex.RunPreCreateNamespaces(ctx, iterationStart, iterationEnd, nsLabels, nsAnnotations, waitListNamespaces, namespacesCreated); err != nil {
+			log.Fatalf("Failed to pre-create namespaces: %v", err)
+		}
+	}
+
 	for i := iterationStart; i < iterationEnd; i++ {
 		if ctx.Err() != nil {
 			return
@@ -290,7 +298,7 @@ func (ex *Executor) createRequest(ctx context.Context, gvr schema.GroupVersionRe
 		return true, err
 	}, 1*time.Second, 3, 0, timeout)
 }
-
+ 
 // RunCreateJobWithChurn executes a churn creation job
 func (ex *Executor) RunCreateJobWithChurn(ctx context.Context) {
 	if ctx.Err() != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,6 +88,7 @@ func (j *Job) UnmarshalYAML(unmarshal func(any) error) error {
 	type rawJob Job
 	raw := rawJob{
 		Cleanup:                true,
+
 		NamespacedIterations:   true,
 		IterationsPerNamespace: 1,
 		PodWait:                false,
@@ -105,6 +106,10 @@ func (j *Job) UnmarshalYAML(unmarshal func(any) error) error {
 		ChurnDelay:             5 * time.Minute,
 		ChurnDeletionStrategy:  "default",
 		MetricsClosing:         AfterJobPause,
+
+		PreCreateNamespaces:       false,        
+	    NamespaceWaitDuration:     0,                  
+	    NamespaceWaitForCondition: nil, 
 	}
 
 	if err := unmarshal(&raw); err != nil {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -129,8 +129,23 @@ type Object struct {
 	KubeVirtOp KubeVirtOpType `yaml:"kubeVirtOp" json:"kubeVirtOp,omitempty"`
 }
 
+//Namespace Handling and Wait Strategy for a Job
+type WaitForCondition struct {
+	Resource string        `yaml:"resource"` // e.g., "networkpolicy", "configmap"
+	Timeout  time.Duration `yaml:"timeout"`  // e.g., 10s
+}
+
+
+
 // Job defines a kube-burner job
 type Job struct {
+	// PreCreateNamespaces creates namespaces before running the job
+	PreCreateNamespaces       bool              `yaml:"preCreateNamespaces"`
+	// NamespaceWaitDuration how long to wait for the namespace to be created
+	NamespaceWaitDuration     time.Duration     `yaml:"namespaceWaitDuration"`
+	// NamespaceWaitForCondition defines a wait condition for the namespace
+	NamespaceWaitForCondition *WaitForCondition `yaml:"namespaceWaitForCondition"`
+
 	// IterationCount how many times to execute the job
 	JobIterations int `yaml:"jobIterations" json:"jobIterations,omitempty"`
 	// IterationDelay how much time to wait between each job iteration

--- a/test-examples/pod.yml
+++ b/test-examples/pod.yml
@@ -1,0 +1,19 @@
+# apiVersion: v1
+# kind: Pod
+# metadata:
+#   name: test-pod
+#   namespace: test-ns
+# spec:
+#   containers:
+#   - name: busybox
+#     image: busybox
+#     command: ["sleep", "3600"]
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example-pod
+spec:
+  containers:
+    - name: pause
+      image: k8s.gcr.io/pause

--- a/test-examples/test-job.yml
+++ b/test-examples/test-job.yml
@@ -1,0 +1,38 @@
+# global:
+#   gc: false 
+
+# jobs:
+# - name: test-ns-pod
+#   jobType: create
+#   jobIterations: 1
+#   namespacedIterations: false   # We control namespace creation ourselves
+#   cleanup: true
+#   qps: 5
+#   burst: 5
+#   objects:
+#     - objectTemplate: namespace.yml
+#       replicas: 1
+#     - objectTemplate: pod.yml
+#       replicas: 1
+
+
+global:
+  gc: false
+
+jobs:
+  - name: precreate-ns-job
+    jobType: create
+    namespace: test-ns
+    jobIterations: 2
+    namespacedIterations: false
+    preCreateNamespaces: true
+    namespaceWaitDuration: 5s
+    namespaceWaitForCondition:
+      resource: networkpolicy
+      timeout: 15s
+    qps: 5
+    burst: 5
+    cleanup: true
+    objects:
+      - objectTemplate: test-examples/pod.yml
+        replicas: 1


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->


- New feature


## Description
This pull request introduces a new feature in kube-burner that allows namespaces to be pre-created and optionally waited upon before the main resource objects are rendered and applied.

<!--- Describe your changes in detail -->
Key Features
   -preCreateNamespaces: true — When set, the namespaces listed in the job's namespace field are created before rendering      and applying objects.

   -waitBeforeCreateObjects: 10s (or any duration) — Optional field that allows users to introduce a delay after namespace creation and before object creation begins.

This addition is useful for cases where other systems (like operators or admission controllers) need the namespace to exist before objects are applied.

## How to test
To test this feature:

1.Ensure kube-burner is built and a Kubernetes cluster is running.

2.Use the sample job file test-examples/test-job.yml to run a simple test

3.Then run:
bin/amd64/kube-burner init -c test-examples/test-job.yml --log-level debug

4.Observe the log output:
 -Namespace Pre-Creation and Reuse Logic:
The job now pre-creates namespaces (test-ns) and attempts to reuse them, which is evident from repeated log entries about namespace creation and object duplication (e.g., Pod already exists)

 -Finally, it will proceed to create the pod or other specified objects

-Object Verification After Job Execution:
  A verification step now runs after object creation to compare expected vs. actual objects, reporting mismatches (e.g., "pods     found: 1 Expected: 2"), helping to catch deployment inconsistencies

-  A delay matching waitBeforeCreateObjects (implementation in progress)

## Related Tickets & Documents

- Related Issue #
- Closes #850 
