### PR TITLE
Adding dynamic logic to create watchers

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -160,6 +160,7 @@ We have watchers support during the benchmark workload. It is at a job level and
 | Option            | Description                                             | Type    | Default |
 |-------------------|---------------------------------------------------------|---------|---------|
 | `kind`            | Object kind to consider for watch                       | String  |    ""   |
+| `apiVersion`      | Object apiVersion to consider for watch                 | String  |    ""   |
 | `labelSelector`   | Objects with these labels will be considered for watch  | Object  |    {}   |
 | `replicas`        | Number of watcher replicas to create                    | Integer |     0   |
 

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -91,7 +91,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 	defer cancel()
 	go func() {
 		var innerRC int
-		clientSet, _ := kubeClientProvider.DefaultClientSet()
+		_, restConfig := kubeClientProvider.DefaultClientSet()
 		measurementsFactory := measurements.NewMeasurementsFactory(configSpec, metricsScraper.MetricsMetadata, additionalMeasurementFactoryMap)
 		jobExecutors = newExecutorList(configSpec, kubeClientProvider, embedCfg)
 		handlePreloadImages(jobExecutors, kubeClientProvider)
@@ -103,10 +103,10 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 				Start:     time.Now().UTC(),
 				JobConfig: jobExecutor.Job,
 			})
-			watcherManager := watchers.NewWatcherManager(clientSet, rate.NewLimiter(rate.Limit(jobExecutor.QPS), jobExecutor.Burst))
+			watcherManager := watchers.NewWatcherManager(restConfig, rate.NewLimiter(rate.Limit(jobExecutor.QPS), jobExecutor.Burst))
 			for idx, watcher := range jobExecutor.Watchers {
 				for replica := range watcher.Replicas {
-					watcherManager.Start(watcher.Kind, watcher.LabelSelector, idx+1, replica+1)
+					watcherManager.Start(watcher.Kind, watcher.APIVersion, watcher.LabelSelector, idx+1, replica+1)
 				}
 			}
 			watcherStartErrors := watcherManager.Wait()

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -224,6 +224,8 @@ type WaitOptions struct {
 type Watcher struct {
 	// Kind object kind to consider for watch
 	Kind string `yaml:"kind" json:"kind,omitempty"`
+	// APIVersion object apiVersion to consider for watch
+	APIVersion string `yaml:"apiVersion" json:"apiVersion,omitempty"`
 	// LabelSelector objects with these labels will be considered
 	LabelSelector map[string]string `yaml:"labelSelector" json:"labelSelector,omitempty"`
 	// Replicas number of replicas to create of the given object

--- a/pkg/measurements/base_measurement.go
+++ b/pkg/measurements/base_measurement.go
@@ -27,6 +27,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -50,9 +52,9 @@ type BaseMeasurement struct {
 }
 
 type MeasurementWatcher struct {
-	restClient    *rest.RESTClient
+	dynamicClient dynamic.Interface
 	name          string
-	resource      string
+	resource      schema.GroupVersionResource
 	labelSelector string
 	handlers      *cache.ResourceEventHandlerFuncs
 }
@@ -66,7 +68,7 @@ func (bm *BaseMeasurement) startMeasurement(measurementWatchers []MeasurementWat
 	for i, measurementWatcher := range measurementWatchers {
 		log.Infof("Creating %v latency watcher for %s", measurementWatcher.resource, bm.JobConfig.Name)
 		bm.watchers[i] = watchers.NewWatcher(
-			measurementWatcher.restClient,
+			measurementWatcher.dynamicClient,
 			measurementWatcher.name,
 			measurementWatcher.resource,
 			corev1.NamespaceAll,

--- a/pkg/measurements/common.go
+++ b/pkg/measurements/common.go
@@ -24,12 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 )
 
@@ -92,26 +88,4 @@ func deployPodInNamespace(clientSet kubernetes.Interface, namespace, podName, im
 		return true, nil
 	})
 	return err
-}
-
-func getGroupVersionClient(restConfig *rest.Config, gv schema.GroupVersion, types ...runtime.Object) *rest.RESTClient {
-	scheme := runtime.NewScheme()
-	codecs := serializer.NewCodecFactory(scheme)
-
-	// Add CDI objects to the scheme
-	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
-	scheme.AddKnownTypes(gv, types...)
-
-	shallowCopy := *restConfig
-	shallowCopy.GroupVersion = &gv
-
-	shallowCopy.APIPath = "/apis"
-	shallowCopy.NegotiatedSerializer = codecs.WithoutConversion()
-	shallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
-
-	cdiClient, err := rest.RESTClientFor(&shallowCopy)
-	if err != nil {
-		log.Fatalf("failed to create CDI Client - %v", err)
-	}
-	return cdiClient
 }

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/kube-burner/kube-burner/pkg/config"
 	"github.com/kube-burner/kube-burner/pkg/measurements/types"
+	"github.com/kube-burner/kube-burner/pkg/util"
 	"github.com/kube-burner/kube-burner/pkg/util/fileutils"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -111,7 +111,11 @@ func (vmilmf vmiLatencyMeasurementFactory) NewMeasurement(jobConfig *config.Job,
 }
 
 func (vmi *vmiLatency) handleCreateVM(obj any) {
-	vm := obj.(*kvv1.VirtualMachine)
+	vm, err := util.ConvertAnyToTyped[kvv1.VirtualMachine](obj)
+	if err != nil {
+		log.Errorf("failed to convert to VirtualMachine: %v", err)
+		return
+	}
 	vmLabels := vm.GetLabels()
 	vmi.metrics.LoadOrStore(string(vm.UID), vmiMetric{
 		Namespace:    vm.Namespace,
@@ -124,7 +128,11 @@ func (vmi *vmiLatency) handleCreateVM(obj any) {
 }
 
 func (vmi *vmiLatency) handleUpdateVM(obj any) {
-	vm := obj.(*kvv1.VirtualMachine)
+	vm, err := util.ConvertAnyToTyped[kvv1.VirtualMachine](obj)
+	if err != nil {
+		log.Errorf("failed to convert to VirtualMachine: %v", err)
+		return
+	}
 	if vmM, ok := vmi.metrics.Load(string(vm.UID)); ok {
 		vmMetric := vmM.(vmiMetric)
 		if vmMetric.vmReady.IsZero() {
@@ -141,7 +149,11 @@ func (vmi *vmiLatency) handleUpdateVM(obj any) {
 }
 
 func (vmi *vmiLatency) handleCreateVMI(obj any) {
-	vmiObj := obj.(*kvv1.VirtualMachineInstance)
+	vmiObj, err := util.ConvertAnyToTyped[kvv1.VirtualMachineInstance](obj)
+	if err != nil {
+		log.Errorf("failed to convert to VirtualMachineInstance: %v", err)
+		return
+	}
 	now := vmiObj.CreationTimestamp.UTC()
 	parentVMID := getParentVMMapID(vmiObj)
 	// in case there's a parent vm
@@ -167,7 +179,11 @@ func (vmi *vmiLatency) handleCreateVMI(obj any) {
 }
 
 func (vmi *vmiLatency) handleUpdateVMI(obj any) {
-	vmiObj := obj.(*kvv1.VirtualMachineInstance)
+	vmiObj, err := util.ConvertAnyToTyped[kvv1.VirtualMachineInstance](obj)
+	if err != nil {
+		log.Errorf("failed to convert to VirtualMachineInstance: %v", err)
+		return
+	}
 	// in case the parent is a VM object
 	mapID := getParentVMMapID(vmiObj)
 	// otherwise use VMI UID
@@ -200,7 +216,11 @@ func (vmi *vmiLatency) handleUpdateVMI(obj any) {
 }
 
 func (vmi *vmiLatency) handleCreateVMIPod(obj any) {
-	pod := obj.(*corev1.Pod)
+	pod, err := util.ConvertAnyToTyped[corev1.Pod](obj)
+	if err != nil {
+		log.Errorf("failed to convert to Pod: %v", err)
+		return
+	}
 	vmiName, err := getParentVMIName(pod)
 	if err != nil {
 		log.Warn(err.Error())
@@ -219,7 +239,11 @@ func (vmi *vmiLatency) handleCreateVMIPod(obj any) {
 }
 
 func (vmi *vmiLatency) handleUpdateVMIPod(obj any) {
-	pod := obj.(*corev1.Pod)
+	pod, err := util.ConvertAnyToTyped[corev1.Pod](obj)
+	if err != nil {
+		log.Errorf("failed to convert to Pod: %v", err)
+		return
+	}
 	vmiName, err := getParentVMIName(pod)
 	if err != nil {
 		log.Warn(err.Error())
@@ -262,13 +286,24 @@ func (vmi *vmiLatency) handleUpdateVMIPod(obj any) {
 // Start starts vmiLatency measurement
 func (vmi *vmiLatency) Start(measurementWg *sync.WaitGroup) error {
 	defer measurementWg.Done()
-	restClient := newRESTClientWithRegisteredKubevirtResource(vmi.RestConfig)
+	vmgvr, err := util.ResourceToGVR(vmi.RestConfig, "VirtualMachine", "kubevirt.io/v1")
+	if err != nil {
+		return fmt.Errorf("error getting GVR for %s: %w", "VirtualMachine", err)
+	}
+	vmigvr, err := util.ResourceToGVR(vmi.RestConfig, "VirtualMachineInstance", "kubevirt.io/v1")
+	if err != nil {
+		return fmt.Errorf("error getting GVR for %s: %w", "VirtualMachineInstance", err)
+	}
+	pgvr, err := util.ResourceToGVR(vmi.RestConfig, "Pod", "v1")
+	if err != nil {
+		return fmt.Errorf("error getting GVR for %s: %w", "Pod", err)
+	}
 	vmi.startMeasurement(
 		[]MeasurementWatcher{
 			{
-				restClient:    restClient,
+				dynamicClient: dynamic.NewForConfigOrDie(vmi.RestConfig),
 				name:          "vmWatcher",
-				resource:      "virtualmachines",
+				resource:      vmgvr,
 				labelSelector: fmt.Sprintf("kube-burner-runid=%v", vmi.Runid),
 				handlers: &cache.ResourceEventHandlerFuncs{
 					AddFunc: vmi.handleCreateVM,
@@ -278,9 +313,9 @@ func (vmi *vmiLatency) Start(measurementWg *sync.WaitGroup) error {
 				},
 			},
 			{
-				restClient:    restClient,
+				dynamicClient: dynamic.NewForConfigOrDie(vmi.RestConfig),
 				name:          "vmiWatcher",
-				resource:      "virtualmachineinstances",
+				resource:      vmigvr,
 				labelSelector: fmt.Sprintf("kube-burner-runid=%v", vmi.Runid),
 				handlers: &cache.ResourceEventHandlerFuncs{
 					AddFunc: vmi.handleCreateVMI,
@@ -290,9 +325,9 @@ func (vmi *vmiLatency) Start(measurementWg *sync.WaitGroup) error {
 				},
 			},
 			{
-				restClient: vmi.ClientSet.CoreV1().RESTClient().(*rest.RESTClient),
-				name:       "podWatcher",
-				resource:   "pods",
+				dynamicClient: dynamic.NewForConfigOrDie(vmi.RestConfig),
+				name:          "podWatcher",
+				resource:      pgvr,
 				labelSelector: labels.Set(
 					map[string]string{
 						"kubevirt.io":       "virt-launcher",
@@ -309,29 +344,6 @@ func (vmi *vmiLatency) Start(measurementWg *sync.WaitGroup) error {
 		},
 	)
 	return nil
-}
-
-func newRESTClientWithRegisteredKubevirtResource(restConfig *rest.Config) *rest.RESTClient {
-	shallowCopy := *restConfig
-	setConfigDefaults(&shallowCopy)
-	restClient, err := rest.RESTClientFor(&shallowCopy)
-	if err != nil {
-		log.Errorf("Error creating custom rest client: %s", err)
-		panic(err)
-	}
-	return restClient
-}
-
-func setConfigDefaults(config *rest.Config) {
-	gv := kvv1.SchemeGroupVersion
-	config.GroupVersion = &gv
-	config.APIPath = "/apis"
-	scheme := runtime.NewScheme()
-	SchemeBuilder := runtime.NewSchemeBuilder(kvv1.AddKnownTypesGenerator(kvv1.GroupVersions))
-	AddToScheme := SchemeBuilder.AddToScheme
-	codecs := serializer.NewCodecFactory(scheme)
-	AddToScheme(scheme)
-	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: codecs}
 }
 
 func (vmi *vmiLatency) Collect(measurementWg *sync.WaitGroup) {

--- a/pkg/watchers/types.go
+++ b/pkg/watchers/types.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 
 	"golang.org/x/time/rate"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -30,11 +30,11 @@ type Watcher struct {
 
 // WatcherManager type to manage watchers
 type WatcherManager struct {
-	clientSet kubernetes.Interface
-	limiter   *rate.Limiter
-	watchers  map[string]*Watcher
-	mu        sync.Mutex
-	wg        sync.WaitGroup
-	errMu     sync.Mutex
-	errs      []error
+	restConfig *rest.Config
+	limiter    *rate.Limiter
+	watchers   map[string]*Watcher
+	mu         sync.Mutex
+	wg         sync.WaitGroup
+	errMu      sync.Mutex
+	errs       []error
 }

--- a/pkg/watchers/watcher.go
+++ b/pkg/watchers/watcher.go
@@ -15,28 +15,59 @@
 package watchers
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
 )
 
 const informerTimeout = time.Minute
 
 // NewWatcher return a new ListWatcher of the specified resource and namespace
-func NewWatcher(restClient *rest.RESTClient, name string, resource string, namespace string, optionsModifier func(options *metav1.ListOptions), indexers cache.Indexers) *Watcher {
-	lw := cache.NewFilteredListWatchFromClient(
-		restClient,
-		resource,
-		namespace,
-		optionsModifier,
-	)
+func NewWatcher(
+	dynamicClient dynamic.Interface,
+	name string,
+	gvr schema.GroupVersionResource,
+	namespace string,
+	optionsModifier func(*metav1.ListOptions),
+	indexers cache.Indexers,
+) *Watcher {
+	resourceNamespaceable := dynamicClient.Resource(gvr)
+
+	var resourceInterface dynamic.ResourceInterface
+	if namespace == corev1.NamespaceAll {
+		resourceInterface = resourceNamespaceable
+	} else {
+		resourceInterface = resourceNamespaceable.Namespace(namespace)
+	}
+
+	lw := &cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			if optionsModifier != nil {
+				optionsModifier(&opts)
+			}
+			return resourceInterface.List(context.TODO(), opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			if optionsModifier != nil {
+				optionsModifier(&opts)
+			}
+			return resourceInterface.Watch(context.TODO(), opts)
+		},
+	}
+
 	return &Watcher{
 		name:        name,
 		stopChannel: make(chan struct{}),
-		Informer:    cache.NewSharedIndexInformer(lw, nil, 0, indexers),
+		Informer:    cache.NewSharedIndexInformer(lw, &unstructured.Unstructured{}, 0, indexers),
 	}
 }
 

--- a/test/k8s/kube-burner.yml
+++ b/test/k8s/kube-burner.yml
@@ -47,10 +47,16 @@ jobs:
     burst: {{ .BURST }}
     watchers:
     - kind: Deployment
+      apiVersion: apps/v1
       labelSelector: {foo: bar}
     - kind: Pod
+      apiVersion: v1
       labelSelector: {foo: bar}
       replicas: 2
+    - kind: MyClusterResource
+      apiVersion: example.com/v1
+      labelSelector: {foo: bar}
+      replicas: 1
     namespacedIterations: true
     preLoadImages: true
     preLoadPeriod: 2s


### PR DESCRIPTION
## Type of change
- Refactor
- New feature
- Bug fix
- Optimization
- CI

## Description
Adding dynamic client to cover left-over watcher use cases from here: https://github.com/kube-burner/kube-burner/pull/865 including CRDs.

## Related Tickets & Documents
Closes # https://github.com/kube-burner/kube-burner/issues/647

## Testing

Tested and verified in local works as expected
* Deploy this CRD on to your cluster
```
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: myclusterresources.example.com
spec:
  group: example.com
  names:
    plural: myclusterresources
    singular: myclusterresource
    kind: MyClusterResource
  scope: Cluster
  versions:
    - name: v1
      served: true
      storage: true
      schema:
        openAPIV3Schema:
          type: object
          properties:
            spec:
              type: object
              # Add your desired properties here
```
* Create a resource with the CRD as below
```
apiVersion: example.com/v1
kind: MyClusterResource
metadata:
  name: my-cluster-resource-5
  labels:
    kube-burner-uuid: tes
```
* Run the below command including CRD to watch in the config yaml file.
```
vchalla@vchalla-thinkpadp1gen2:~/myforks/kube-burner/test/k8s$ kube-burner init -c kube-burner.yml --uuid="${UUID}" 
time="2025-07-08 22:42:52" level=info msg="🔥 Starting kube-burner (main@c407ac0c6c94a5d73ef27d1b3ad019fe99192892) with UUID ccab3689-e455-48f5-9e14-60341b73222f" file="job.go:89"
time="2025-07-08 22:42:52" level=info msg="📈 Registered measurement: podLatency" file="factory.go:108"
time="2025-07-08 22:42:52" level=info msg="📈 Registered measurement: nodeLatency" file="factory.go:108"
time="2025-07-08 22:42:52" level=info msg="📈 Registered measurement: serviceLatency" file="factory.go:108"
time="2025-07-08 22:42:52" level=info msg="📈 Registered measurement: jobLatency" file="factory.go:108"
time="2025-07-08 22:42:52" level=info msg="QPS: 3" file="job.go:360"
time="2025-07-08 22:42:52" level=info msg="Burst: 3" file="job.go:367"
time="2025-07-08 22:42:53" level=info msg="Job namespaced: 5 iterations with 1 Deployment replicas" file="create.go:83"
time="2025-07-08 22:42:53" level=info msg="Job namespaced: 5 iterations with 1 Pod replicas" file="create.go:83"
time="2025-07-08 22:42:53" level=info msg="Job namespaced: 5 iterations with 1 Job replicas" file="create.go:83"
time="2025-07-08 22:42:53" level=info msg="Job namespaced: 5 iterations with 1 Service replicas" file="create.go:83"
time="2025-07-08 22:42:53" level=info msg="Job namespaced: 5 iterations with 1 Secret replicas" file="create.go:83"
time="2025-07-08 22:42:53" level=info msg="Pre-load: images from job namespaced" file="pre_load.go:73"
time="2025-07-08 22:42:53" level=info msg="Pre-load: Creating DaemonSet using images [quay.io/cloud-bulldozer/sampleapp:latest gcr.io/google_containers/pause:3.2 gcr.io/k8s-staging-perf-tests/sleep:v0.1.0] in namespace preload-kube-burner" file="pre_load.go:195"
time="2025-07-08 22:42:53" level=info msg="Pre-load: Sleeping for 2s" file="pre_load.go:86"
time="2025-07-08 22:42:55" level=info msg="Deleting 1 namespaces with label: kube-burner-preload=true" file="namespaces.go:67"
time="2025-07-08 22:43:02" level=info msg="Started pod_watcher_2_replica_2" file="watcher_manager.go:73"
time="2025-07-08 22:43:02" level=info msg="Started myclusterresource_watcher_3_replica_1" file="watcher_manager.go:73"
time="2025-07-08 22:43:02" level=info msg="Started pod_watcher_2_replica_1" file="watcher_manager.go:73"
time="2025-07-08 22:43:02" level=info msg="Started deployment_watcher_1_replica_1" file="watcher_manager.go:73"
time="2025-07-08 22:43:03" level=info msg="Creating batch/v1, Resource=jobs latency watcher for namespaced" file="base_measurement.go:69"
time="2025-07-08 22:43:03" level=info msg="Creating /v1, Resource=pods latency watcher for namespaced" file="base_measurement.go:69"
time="2025-07-08 22:43:03" level=info msg="Creating /v1, Resource=nodes latency watcher for namespaced" file="base_measurement.go:69"
time="2025-07-08 22:43:05" level=info msg="Triggering job: namespaced" file="job.go:120"
time="2025-07-08 22:43:06" level=info msg="Deleting Pods labeled with kube-burner-job=namespaced in default" file="namespaces.go:55"
time="2025-07-08 22:43:06" level=info msg="0/5 iterations completed" file="create.go:118"
time="2025-07-08 22:43:08" level=info msg="Sleeping for 5s" file="create.go:161"
time="2025-07-08 22:43:13" level=info msg="Sleeping for 5s" file="create.go:161"
time="2025-07-08 22:43:19" level=info msg="Sleeping for 5s" file="create.go:161"
time="2025-07-08 22:43:24" level=info msg="Sleeping for 5s" file="create.go:161"
time="2025-07-08 22:43:30" level=info msg="Sleeping for 5s" file="create.go:161"
time="2025-07-08 22:43:35" level=info msg="Waiting up to 2m0s for actions to be completed" file="create.go:168"
time="2025-07-08 22:43:35" level=info msg="Actions in namespace namespaced-1 completed" file="waiters.go:74"
time="2025-07-08 22:43:36" level=info msg="Actions in namespace namespaced-2 completed" file="waiters.go:74"
time="2025-07-08 22:43:36" level=info msg="Actions in namespace namespaced-0 completed" file="waiters.go:74"
time="2025-07-08 22:43:37" level=info msg="Actions in namespace namespaced-3 completed" file="waiters.go:74"
time="2025-07-08 22:43:37" level=info msg="Actions in namespace namespaced-4 completed" file="waiters.go:74"
time="2025-07-08 22:43:37" level=info msg="Verifying created objects" file="utils.go:119"
time="2025-07-08 22:43:39" level=info msg="Job namespaced took 38s" file="job.go:187"
time="2025-07-08 22:43:39" level=info msg="Stopping measurement: podLatency" file="factory.go:149"
time="2025-07-08 22:43:39" level=info msg="namespaced: PodScheduled 99th: 500 max: 1000 avg: 100" file="base_measurement.go:111"
time="2025-07-08 22:43:39" level=info msg="namespaced: ContainersReady 99th: 2500 max: 3000 avg: 1500" file="base_measurement.go:111"
time="2025-07-08 22:43:39" level=info msg="namespaced: Initialized 99th: 1000 max: 1000 avg: 200" file="base_measurement.go:111"
time="2025-07-08 22:43:39" level=info msg="namespaced: Ready 99th: 2500 max: 3000 avg: 1500" file="base_measurement.go:111"
time="2025-07-08 22:43:39" level=info msg="namespaced: PodReadyToStartContainers 99th: 0 max: 0 avg: 0" file="base_measurement.go:111"
time="2025-07-08 22:43:39" level=info msg="Stopping measurement: nodeLatency" file="factory.go:149"
time="2025-07-08 22:43:39" level=info msg="Stopping measurement: serviceLatency" file="factory.go:149"
time="2025-07-08 22:43:39" level=info msg="Deleting 1 namespaces with label: kubernetes.io/metadata.name=kube-burner-service-latency" file="namespaces.go:67"
time="2025-07-08 22:43:45" level=info msg="Stopping measurement: jobLatency" file="factory.go:149"
time="2025-07-08 22:43:45" level=info msg="namespaced: StartTime 99th: 500 max: 1000 avg: 200" file="base_measurement.go:111"
time="2025-07-08 22:43:45" level=info msg="namespaced: Complete 99th: 7000 max: 7000 avg: 6400" file="base_measurement.go:111"
time="2025-07-08 22:43:45" level=info msg="Stopping myclusterresource_watcher_3_replica_1" file="watcher_manager.go:95"
time="2025-07-08 22:43:45" level=info msg="Stopping pod_watcher_2_replica_1" file="watcher_manager.go:95"
time="2025-07-08 22:43:45" level=info msg="Stopping deployment_watcher_1_replica_1" file="watcher_manager.go:95"
time="2025-07-08 22:43:45" level=info msg="Stopping pod_watcher_2_replica_2" file="watcher_manager.go:95"
time="2025-07-08 22:43:45" level=info msg="Finished execution with UUID: ccab3689-e455-48f5-9e14-60341b73222f" file="job.go:259"
time="2025-07-08 22:43:45" level=info msg="Garbage collecting jobs" file="job.go:286"
time="2025-07-08 22:43:45" level=info msg="Deleting 5 namespaces with label: kube-burner-job=namespaced" file="namespaces.go:67"
time="2025-07-08 22:44:33" level=info msg="Deleting Pods labeled with kube-burner-job=namespaced in default" file="namespaces.go:55"
time="2025-07-08 22:44:34" level=info msg="👋 Exiting kube-burner ccab3689-e455-48f5-9e14-60341b73222f" file="kube-burner.go:90"
```
