### PR TITLE
Add failed to wait build status phase

### DIFF
--- a/pkg/burner/waiters.go
+++ b/pkg/burner/waiters.go
@@ -214,7 +214,7 @@ func (ex *JobExecutor) waitForPod(ns string, labelSelector string) error {
 }
 
 func (ex *JobExecutor) waitForBuild(ns string, obj *object, labelSelector string) error {
-	buildStatus := []string{"New", "Pending", "Running"}
+	buildStatus := []string{"New", "Pending", "Running", "Failed"}
 	var build types.UnstructuredContent
 	err := wait.PollUntilContextTimeout(context.TODO(), time.Second, ex.MaxWaitTimeout, true, func(ctx context.Context) (done bool, err error) {
 		ex.limiter.Wait(context.TODO())


### PR DESCRIPTION
- Bug fix

## Description

Failed was missing from the list of status

## Related Tickets & Documents

- Related Issue https://github.com/kube-burner/kube-burner/issues/1020
- Closes #
