### PR TITLE
Create a cache typed informer for the svcLister

### DIFF
--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -51,7 +51,7 @@ var supportedServiceLatencyJobTypes = map[config.JobType]struct{}{
 
 type serviceLatency struct {
 	BaseMeasurement
-  stopInformerCh    chan struct{}
+	stopInformerCh    chan struct{}
 	epsLister         ldiscoveryv1.EndpointSliceLister
 	svcLister         lcorev1.ServiceLister
 	svcLatencyChecker *mutil.SvcLatencyChecker
@@ -206,7 +206,7 @@ func (s *serviceLatency) Start(measurementWg *sync.WaitGroup) error {
 	factory := informers.NewSharedInformerFactory(clientset, 0)
 	// EndpointSlice/Service lister & informer from typed client
 	s.epsLister = factory.Discovery().V1().EndpointSlices().Lister()
-    s.svcLister = factory.Core().V1().Services().Lister()
+	s.svcLister = factory.Core().V1().Services().Lister()
 	epsInformer := factory.Discovery().V1().EndpointSlices().Informer()
 	svcInformer := factory.Core().V1().Services().Informer()
 


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

The service lister should have it's own cache typed informer to prevent type conversion panics as described in #1023 

## Related Tickets & Documents

- Related Issue #
- Closes #1023 

cc @afcollins @sferlin

