### PR TITLE
Stop all watchers and wait for cache sync before collecting the measurements

### DIFF
--- a/pkg/measurements/base_measurement.go
+++ b/pkg/measurements/base_measurement.go
@@ -96,7 +96,7 @@ func (bm *BaseMeasurement) stopWatchers() {
 
 func (bm *BaseMeasurement) StopMeasurement(normalizeMetrics func() float64, getLatency func(any) map[string]float64) error {
 	var err error
-	defer bm.stopWatchers()
+	bm.stopWatchers()
 	errorRate := normalizeMetrics()
 	if errorRate > 10.00 {
 		log.Error("Latency errors beyond 10%. Hence invalidating the results")

--- a/test/k8s/kube-burner-measurements.yml
+++ b/test/k8s/kube-burner-measurements.yml
@@ -14,7 +14,7 @@ jobs:
   - name: precedence-measurements
     measurements:
       - name: podLatency
-    jobIterations: 5
+    jobIterations: 1
     namespace: precedence-measurements
     namespacedIterations: true
     preLoadImages: false
@@ -32,7 +32,7 @@ jobs:
     measurements:
       - name: serviceLatency
         svcTimeout: 5s
-    jobIterations: 5
+    jobIterations: 1
     namespace: merge-measurements
     namespacedIterations: true
     preLoadImages: false


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

Thanks to a flacky test that can be observed at https://github.com/kube-burner/kube-burner/actions/runs/19163907877/job/54780056514?pr=1024#step:5:137, its been detected that there're situations where no documents are indexed by the podLatency measurement.

When stopping the pod latency measurement it's possible that the pod watcher hasn't received the pod yet, for that reason we should normalize the metrics after stopping the watcher.


## Related Tickets & Documents

- Related Issue #
- Closes #
