### PR TITLE
Add space for service latency log to play nicer with double-click

### DIFF
--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -243,7 +243,7 @@ func (s *serviceLatency) Stop() error {
 	for _, q := range s.LatencyQuantiles {
 		pq := q.(metrics.LatencyQuantiles)
 		// Divide nanoseconds by 1e6 to get milliseconds
-		log.Infof("serviceLatency: %s: %s 99th: %dms max: %dms avg: %dms", s.JobConfig.Name, pq.QuantileName, pq.P99/1e6, pq.Max/1e6, pq.Avg/1e6)
+		log.Infof("serviceLatency: %s: %s 99th: %d ms max: %d ms avg: %d ms", s.JobConfig.Name, pq.QuantileName, pq.P99/1e6, pq.Max/1e6, pq.Avg/1e6)
 	}
 	return nil
 }


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Refactor

## Description

Service latencies are now printed with no space between the measurement and the unit ('ms'). When the string is double-clicked, say to copy in order to paste somewhere else, it includes the 'ms'.

To compare with our other measurements, pod latency units are not printed. This change makes the behavior slightly more consistent.