### PR TITLE
Reduce GVR logging

### DIFF
--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -32,6 +32,7 @@ import (
 func CleanupNamespacesUsingGVR(ctx context.Context, ex JobExecutor, namespacesToDelete []string) {
 	labelSelector := fmt.Sprintf("%s=%s", config.KubeBurnerLabelJob, ex.Name)
 	for _, namespace := range namespacesToDelete {
+		log.Infof("Deleting namespace %s using GVR", namespace)
 		for _, obj := range ex.objects {
 			CleanupNamespaceResourcesUsingGVR(ctx, ex, obj, namespace, labelSelector)
 		}
@@ -42,7 +43,7 @@ func CleanupNamespacesUsingGVR(ctx context.Context, ex JobExecutor, namespacesTo
 func CleanupNamespaceResourcesUsingGVR(ctx context.Context, ex JobExecutor, obj *object, namespace string, labelSelector string) {
 	resourceInterface := ex.dynamicClient.Resource(obj.gvr).Namespace(namespace)
 	resources, err := resourceInterface.List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
-	log.Infof("Deleting %ss labeled with %s in %s", obj.Kind, labelSelector, namespace)
+	log.Debugf("Deleting %ss labeled with %s in %s", obj.Kind, labelSelector, namespace)
 	if err != nil {
 		log.Errorf("Unable to list %vs in %v: %v", obj.Kind, namespace, err)
 		return


### PR DESCRIPTION

## Type of change

- Refactor

## Description

Decreases log level of resource-label delete to Debug, which is quite noisy in a workload like node-density-cni. Instead, this adds a log message for deleting a namespace using GVR.