### PR TITLE
feature: jobs.preLoadImage added for custom preLoadImage

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -202,6 +202,8 @@ type Job struct {
 	GC bool `yaml:"gc" json:"gc"`
 	// Measurements job-specific measurements to enable
 	Measurements []mtypes.Measurement `yaml:"measurements" json:"measurements,omitempty"`
+	//PreLoadImage allows for custom images
+	PreLoadImage string `yaml:"preLoadImage" json:"preLoadImage,omitempty"`
 }
 
 type WaitOptions struct {


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- New feature

## Description
A `preLoadImage` field in the job config is added so that the image can be customized as needed 

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Closes #1036
