### PR TITLE
fix Nil pointer issue

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -320,6 +320,10 @@ func (ex *JobExecutor) createRequest(ctx context.Context, gvr schema.GroupVersio
 		} else {
 			if !ex.nsChurning {
 				uns, err = ex.dynamicClient.Resource(gvr).Create(context.TODO(), obj, metav1.CreateOptions{})
+			} else {
+				// Skip non-namespaced objects during namespace churning - they won't be deleted with the namespace
+				log.Debugf("Skipping non-namespaced object %s/%s during namespace churning", obj.GetKind(), obj.GetName())
+				return true, nil
 			}
 		}
 		if err != nil {


### PR DESCRIPTION
## Type of change

<!-- Choose a type of change -->

- Bug fix

## Description

  - When namespace churning is enabled (nsChurning=true) and processing a cluster-scoped object (ns=""), the code now:
    a. Logs a debug message explaining why the object is being skipped
    b. Returns early with return true, nil to exit the retry loop cleanly
    c. Prevents falling through to the logging code that would call uns.GetKind() on nil

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #1066 
