### PR TITLE
Remove set flag from cmd helpers

### DIFF
--- a/pkg/util/cmd.go
+++ b/pkg/util/cmd.go
@@ -30,7 +30,6 @@ import (
 // Bootstraps kube-burner cmd with some common flags
 func SetupCmd(cmd *cobra.Command) {
 	cmd.PersistentFlags().String("log-level", "info", "Allowed values: debug, info, warn, error, fatal")
-	cmd.PersistentFlags().String("set", "", "Set values for template variables or override workflow file. Format: key1=val1,key2=val2")
 	cmd.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of kube-burner",


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

This flag, not used, is incorrectly defined and prevents `kube-burner-ocp` to redeclare it.


```shell
 ./bin/amd64/kube-burner-ocp -h                                     
panic: kube-burner-ocp flag redefined: set                                                                             
                                                                                                                                                                                                                                              
goroutine 1 [running]:                                                                                                 
github.com/spf13/pflag.(*FlagSet).AddFlag(0xc000316100, 0xc0000392c0)                                                  
        /var/home/rsevilla/go/pkg/mod/github.com/spf13/pflag@v1.0.6-0.20210604193023-d5e0c0615ace/flag.go:855 +0x5fc                                                                                                                          
github.com/spf13/pflag.(*FlagSet).VarPF(0xc000316100, {0x2fb2f80, 0xc00045dbb0}, {0x2b785ea, 0x3}, {0x0, 0x0}, {0x2c157dc, 0x58})
        /var/home/rsevilla/go/pkg/mod/github.com/spf13/pflag@v1.0.6-0.20210604193023-d5e0c0615ace/flag.go:838 +0x105                                                                                                                          
github.com/spf13/pflag.(*FlagSet).VarP(...)                                                                            
        /var/home/rsevilla/go/pkg/mod/github.com/spf13/pflag@v1.0.6-0.20210604193023-d5e0c0615ace/flag.go:844                                                                                                                                 
github.com/spf13/pflag.(*FlagSet).StringVarP(...)                                                                                                                                                                                             
        /var/home/rsevilla/go/pkg/mod/github.com/spf13/pflag@v1.0.6-0.20210604193023-d5e0c0615ace/string.go:42                                                                                                                                
github.com/spf13/pflag.(*FlagSet).String(0xc000316100, {0x2b785ea, 0x3}, {0x0, 0x0}, {0x2c157dc, 0x58})                                                                                                                                       
        /var/home/rsevilla/go/pkg/mod/github.com/spf13/pflag@v1.0.6-0.20210604193023-d5e0c0615ace/string.go:60 +0xb3   
github.com/kube-burner/kube-burner/v2/pkg/util.SetupCmd(0xc000366008)                                                                                                                                                                         
        /var/home/rsevilla/go/pkg/mod/github.com/kube-burner/kube-burner/v2@v2.1.0/pkg/util/cmd.go:33 +0x72            
main.openShiftCmd()                                                                                                                                                                                                                           
        /var/home/rsevilla/labs/kube-burner-ocp/cmd/ocp.go:153 +0xdaf                                                  
main.main()                                                                                                            
        /var/home/rsevilla/labs/kube-burner-ocp/cmd/ocp.go:158 +0x13                                                             
```

## Related Tickets & Documents

- Related Issue #
- Closes #
