### PR TITLE
Adding space between measurement value and unit.

### DIFF
--- a/pkg/measurements/base_measurement.go
+++ b/pkg/measurements/base_measurement.go
@@ -124,7 +124,7 @@ func (bm *BaseMeasurement) StopMeasurement(normalizeMetrics func() float64, getL
 	}
 	for _, q := range bm.LatencyQuantiles {
 		pq := q.(metrics.LatencyQuantiles)
-		log.Infof("%s: %v 99th: %vms max: %vms avg: %vms", bm.JobConfig.Name, pq.QuantileName, pq.P99, pq.Max, pq.Avg)
+		log.Infof("%s: %v 99th: %v ms max: %v ms avg: %v ms", bm.JobConfig.Name, pq.QuantileName, pq.P99, pq.Max, pq.Avg)
 	}
 	if errorRate > 0 {
 		log.Infof("%v error rate was: %.2f", bm.MeasurementName, errorRate)


### PR DESCRIPTION
## Type of change


- Refactor

## Description

Without a space between measurement value and the units, double-click selects the unit, which is then not processed as a number and requires manual removal.

A space was added for service latency measurement before in #1050, I must have missed this one at that time.

I hope this is alright and doesn't interfere with any who might have created log-parsers.

## Related Tickets & Documents

- Related Issue #1030
