### PR TITLE
Bound goroutine creation in replicaHandler

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -213,10 +213,12 @@ func (ex *JobExecutor) replicaHandler(ctx context.Context, labels map[string]str
 		maps.Copy(copiedLabels, labels)
 		copiedLabels[config.KubeBurnerLabelReplica] = strconv.Itoa(r)
 
+		if err := ex.limiter.Wait(ctx); err != nil {
+			return
+		}
 		wg.Add(1)
 		go func(r int) {
 			defer wg.Done()
-			ex.limiter.Wait(context.TODO())
 			newObjects, gvks := ex.renderTemplateForObjectMultiple(obj, iteration, r)
 			newObject := newObjects[obj.documentIndex]
 			gvk := gvks[obj.documentIndex]


### PR DESCRIPTION
This PR fixes an issue where goroutines were created in a loop before waiting
on the rate limiter. With large replica counts, this could result in many
goroutines being spawned at once.

The rate limiter is now awaited before starting each goroutine, and the
existing context is used so cancellation is respected. This keeps the behavior
the same while making execution safer.

Fixes #1093 