### PR TITLE
Make deployinNamespace public

### DIFF
--- a/pkg/measurements/common.go
+++ b/pkg/measurements/common.go
@@ -40,7 +40,7 @@ func getIntFromLabels(labels map[string]string, key string) int {
 	return 0
 }
 
-func deployPodInNamespace(clientSet kubernetes.Interface, namespace, podName, image string, command []string) error {
+func DeployPodInNamespace(clientSet kubernetes.Interface, namespace, podName, image string, command []string) error {
 	var podObj = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,

--- a/pkg/measurements/netpol_latency.go
+++ b/pkg/measurements/netpol_latency.go
@@ -527,7 +527,7 @@ func (n *netpolLatency) Start(measurementWg *sync.WaitGroup) error {
 	}
 	_, err = n.ClientSet.CoreV1().Pods(networkPolicyProxy).Get(context.TODO(), networkPolicyProxy, metav1.GetOptions{})
 	if err != nil {
-		err = deployPodInNamespace(n.ClientSet, networkPolicyProxy, networkPolicyProxy, "quay.io/cloud-bulldozer/netpolproxy:latest", nil)
+		err = DeployPodInNamespace(n.ClientSet, networkPolicyProxy, networkPolicyProxy, "quay.io/cloud-bulldozer/netpolproxy:latest", nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -179,7 +179,7 @@ func (s *serviceLatency) Start(measurementWg *sync.WaitGroup) error {
 	defer measurementWg.Done()
 
 	s.LatencyQuantiles, s.NormLatencies = nil, nil
-	if err := deployPodInNamespace(
+	if err := DeployPodInNamespace(
 		s.ClientSet,
 		types.SvcLatencyNs,
 		types.SvcLatencyCheckerName,


### PR DESCRIPTION
## Type of change

- Refactor

## Description

As part of the effort to move the network policy measurement (This measurement is not vanilla k8s friendly) outside of this repo, we need to make this function public.

## Related Tickets & Documents

- Related Issue #
- Closes #
