### PR TITLE
Cache compiled templates to avoid repeated runtime work

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -73,8 +73,7 @@ func (p *Prometheus) ScrapeJobsMetrics(jobList ...Job) error {
 				eachJob.JobConfig.MetricsClosing)
 			for _, metric := range metricProfile.metrics {
 				requiresInstant := false
-				t, _ := template.New("").Parse(metric.Query)
-				if err := t.Execute(&renderedQuery, vars); err != nil {
+				if err := metric.template.Execute(&renderedQuery, vars); err != nil {
 					log.Warnf("Error rendering query: %v", err)
 					continue
 				}
@@ -148,6 +147,10 @@ func (p *Prometheus) ReadProfile(location string, embedCfg *fileutils.EmbedConfi
 		}
 		if md.MetricName == "" {
 			return fmt.Errorf("metricName not defined in query number %d", i+1)
+		}
+		metricProfile.metrics[i].template, err = template.New("").Parse(md.Query)
+		if err != nil {
+			return fmt.Errorf("error parsing template for query %d: %s", i+1, err)
 		}
 	}
 	p.MetricProfiles = append(p.MetricProfiles, metricProfile)

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -15,6 +15,7 @@
 package prometheus
 
 import (
+	"text/template"
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/v2/indexers"
@@ -62,6 +63,7 @@ type metricDefinition struct {
 	MetricName   string `yaml:"metricName"`
 	Instant      bool   `yaml:"instant"`
 	CaptureStart bool   `yaml:"captureStart"`
+	template     *template.Template
 }
 
 type metric struct {


### PR DESCRIPTION
This change moves template parsing and compilation out of hot execution paths and caches the compiled templates during initialization.
The cached templates are reused during metric scraping and alert evaluation, reducing unnecessary CPU overhead while keeping behavior and APIs unchanged.

Clean, minimal, and focused only on the performance issue.
Fixes #1100 