### PR TITLE
Changess GVR deletion log message from Info to Debug

### DIFF
--- a/pkg/burner/namespaces.go
+++ b/pkg/burner/namespaces.go
@@ -55,7 +55,7 @@ func CleanupNamespaceResourcesByLabel(ctx context.Context, ex JobExecutor, obj *
 		return
 	}
 	if len(resources.Items) > 0 {
-		log.Infof("Deleting %d %ss labeled with %s in %s", len(resources.Items), obj.Kind, labelSelector, namespace)
+		log.Debugf("Deleting %d %ss labeled with %s in %s", len(resources.Items), obj.Kind, labelSelector, namespace)
 	}
 	for _, item := range resources.Items {
 		if err := resourceInterface.Delete(ctx, item.GetName(), metav1.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationBackground)}); err != nil {


### PR DESCRIPTION
## Type of change

- Refactor

## Description

GVR Deletion scheme generates a lot of logs. Much of it comes from logging every resource that is deleted.

This seems like 'debug' level information. Logging when a namespace is deleted seems sufficient for 'info' level logging.
