### PR TITLE
Fix file descriptor leak by closing workload reader

### DIFF
--- a/pkg/burner/object.go
+++ b/pkg/burner/object.go
@@ -79,6 +79,9 @@ func newObject(obj config.Object, mapper *restmapper.DeferredDiscoveryRESTMapper
 		if err != nil {
 			log.Fatalf("Error reading template %s: %s", obj.ObjectTemplate, err)
 		}
+		if closer, ok := f.(io.Closer); ok {
+			defer closer.Close()
+		}
 		t, err := io.ReadAll(f)
 		if err != nil {
 			log.Fatalf("Error reading template %s: %s", obj.ObjectTemplate, err)


### PR DESCRIPTION
This PR fixes a resource leak caused by an unclosed reader returned from GetWorkloadReader().

The reader internally opens a file but was not being closed after use, which could lead to file descriptor exhaustion in long-running or repeated executions. The fix ensures the resource is properly closed once it is consumed, without changing existing behavior or public APIs.

The change is intentionally minimal and scoped only to resource cleanup.

Fixes #1117 