### PR TITLE
Fetch origin/main branch

### DIFF
--- a/.github/workflows/test-k8s.yml
+++ b/.github/workflows/test-k8s.yml
@@ -38,12 +38,18 @@ jobs:
         k8s-version: ${{ fromJson(needs.fetch-latest-kind-node-tags.outputs.tags) }}
     steps:
 
-    - name: Check out code
+    - name: Checkout PR head
       uses: actions/checkout@v6
       with:
-        fetch-depth: 1
+        # Use the PR head SHA
         ref: ${{ github.event.pull_request.head.sha }}
+        # Fetch only the most recent commit of the PR
+        fetch-depth: 1
         persist-credentials: false
+
+    - name: Fetch base branch for comparison
+      # This tells Git about origin/main (or master) without downloading the whole repo
+      run: git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
 
     - name: Download kube-burner binary
       uses: actions/download-artifact@v7


### PR DESCRIPTION
## Type of change

- CI

## Description

This command https://github.com/kube-burner/kube-burner/blob/main/hack/get_changed_labels.py#L20 is not working, since the current logic clones a swallow copy of the PRs branch, we need to fetch the origin/main branch to perform the diff comparison

Issues can be observed in workflow runs., i.e: https://github.com/kube-burner/kube-burner/actions/runs/21670432379/job/62476738548

<img width="1996" height="325" alt="image" src="https://github.com/user-attachments/assets/c2924001-7699-4b13-984b-a6ecbfe6bf7d" />


## Related Tickets & Documents

- Related Issue #
- Closes #
