### PR TITLE
Fix uuid argument

### DIFF
--- a/cmd/kube-burner/kube-burner.go
+++ b/cmd/kube-burner/kube-burner.go
@@ -275,7 +275,7 @@ func measureCmd() *cobra.Command {
 			if err != nil {
 				log.Fatalf("Error reading configuration file %s: %s", configFile, err)
 			}
-			configSpec, err := config.Parse(configFile, time.Hour, f)
+			configSpec, err := config.Parse(uuid, time.Hour, f)
 			if err != nil {
 				log.Fatal(err.Error())
 			}


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

Parse expects an uuid, not a config file name

## Related Tickets & Documents

- Related Issue #
- Closes #
