### PR TITLE
Keep ownersRefereces field from pod objects

### DIFF
--- a/pkg/measurements/transforms.go
+++ b/pkg/measurements/transforms.go
@@ -63,7 +63,7 @@ func defaultMetadataTransformOpts() metadataTransformOptions {
 }
 
 // PodTransformFunc preserves the following fields for latency measurements:
-// - metadata: name, namespace, uid, creationTimestamp, labels
+// - metadata: name, namespace, uid, creationTimestamp, labels, ownerReferences
 // - spec: nodeName
 // - status: conditions
 func PodTransformFunc() cache.TransformFunc {
@@ -73,7 +73,11 @@ func PodTransformFunc() cache.TransformFunc {
 			return obj, nil
 		}
 
-		minimal := createMinimalUnstructured(u, defaultMetadataTransformOpts())
+		minimal := createMinimalUnstructured(u, metadataTransformOptions{
+			includeNamespace:       true,
+			includeLabels:          true,
+			includeOwnerReferences: true,
+		})
 
 		if nodeName, found, _ := unstructured.NestedString(u.Object, "spec", "nodeName"); found && nodeName != "" {
 			_ = unstructured.SetNestedField(minimal.Object, nodeName, "spec", "nodeName")


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

Mistakenly trimmed by https://github.com/kube-burner/kube-burner/pull/1081, this field is used in the vmi latency measurement

https://github.com/kube-burner/kube-burner/blob/c02a7213b3dbb81b46cc4608aa86c2962a3a1ae4/pkg/measurements/vmi_latency.go#L420
