### PR TITLE
Optimize template compilation in hot paths

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -73,8 +73,7 @@ func (p *Prometheus) ScrapeJobsMetrics(jobList ...Job) error {
 				eachJob.JobConfig.MetricsClosing)
 			for _, metric := range metricProfile.metrics {
 				requiresInstant := false
-				t, _ := template.New("").Parse(metric.Query)
-				if err := t.Execute(&renderedQuery, vars); err != nil {
+				if err := metric.queryTemplate.Execute(&renderedQuery, vars); err != nil {
 					log.Warnf("Error rendering query: %v", err)
 					continue
 				}
@@ -149,6 +148,11 @@ func (p *Prometheus) ReadProfile(location string, embedCfg *fileutils.EmbedConfi
 		if md.MetricName == "" {
 			return fmt.Errorf("metricName not defined in query number %d", i+1)
 		}
+		t, err := template.New(md.MetricName).Parse(md.Query)
+		if err != nil {
+			return fmt.Errorf("error parsing query %s: %v", md.Query, err)
+		}
+		metricProfile.metrics[i].queryTemplate = t
 	}
 	p.MetricProfiles = append(p.MetricProfiles, metricProfile)
 	return nil

--- a/pkg/prometheus/types.go
+++ b/pkg/prometheus/types.go
@@ -15,6 +15,7 @@
 package prometheus
 
 import (
+	"text/template"
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/v2/indexers"
@@ -58,10 +59,11 @@ type metricProfile struct {
 
 // metricDefinition describes what metrics kube-burner collects
 type metricDefinition struct {
-	Query        string `yaml:"query"`
-	MetricName   string `yaml:"metricName"`
-	Instant      bool   `yaml:"instant"`
-	CaptureStart bool   `yaml:"captureStart"`
+	Query         string `yaml:"query"`
+	MetricName    string `yaml:"metricName"`
+	Instant       bool   `yaml:"instant"`
+	CaptureStart  bool   `yaml:"captureStart"`
+	queryTemplate *template.Template
 }
 
 type metric struct {


### PR DESCRIPTION
This change moves template parsing and compilation out of frequently executed paths and into profile initialization.

Alert expressions, alert descriptions, and metric queries are now compiled once when profiles are loaded and reused during evaluation and scraping. This avoids repeated template parsing inside hot loops, reducing unnecessary CPU overhead and latency, especially at scale.

The behavior and output remain unchanged; the update is strictly an internal performance optimization.
 
Fixes #1110 