### PR TITLE
Fix gvr deletion strategy deleting kube-burner namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/prometheus/common v0.62.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/time v0.10.0
 	gonum.org/v1/gonum v0.15.1
@@ -72,6 +73,8 @@ require (
 	github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183 // indirect
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47 // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.68.0 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
@@ -88,6 +91,7 @@ require (
 	golang.org/x/text v0.26.0 // indirect
 	golang.org/x/tools v0.33.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.31.0 // indirect

--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -428,10 +428,6 @@ func (ex *JobExecutor) gc(ctx context.Context, wg *sync.WaitGroup) {
 				namespacesToDelete = append(namespacesToDelete, ns.Name)
 			}
 			CleanupNamespacesUsingGVR(ctx, *ex, namespacesToDelete)
-			err := util.CleanupNamespacesByLabel(ctx, ex.clientSet, labelSelector)
-			if err != nil {
-				log.Error(err.Error())
-			}
 		}
 	} else {
 		err := util.CleanupNamespacesByLabel(ctx, ex.clientSet, labelSelector)

--- a/pkg/burner/job_test.go
+++ b/pkg/burner/job_test.go
@@ -1,0 +1,83 @@
+package burner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kube-burner/kube-burner/v2/pkg/config"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGarbageCollectionGVR(t *testing.T) {
+	ctx := context.TODO()
+	nsName := "kube-burner-job-1"
+	// labelSelector := fmt.Sprintf("%s=%s", config.KubeBurnerLabelJob, "job-1")
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+			Labels: map[string]string{
+				config.KubeBurnerLabelJob: "job-1",
+			},
+		},
+	}
+	objects := []runtime.Object{ns}
+	fakeClient := fake.NewSimpleClientset(objects...)
+
+	// Setup JobExecutor
+	ex := JobExecutor{
+		Job: config.Job{
+			Name: "job-1",
+		},
+		clientSet:        fakeClient,
+		deletionStrategy: config.GVRDeletionStrategy,
+	}
+
+	// Execute GC
+	ex.gc(ctx, nil)
+
+	// Verify namespace still exists
+	_, err := fakeClient.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+	assert.NoError(t, err, "Namespace should NOT be deleted when deletionStrategy is gvr")
+}
+
+func TestGarbageCollectionDefault(t *testing.T) {
+	ctx := context.TODO()
+	// Setup fake client
+	nsName := "kube-burner-job-2"
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+			Labels: map[string]string{
+				config.KubeBurnerLabelJob: "job-2",
+			},
+		},
+	}
+	objects := []runtime.Object{ns}
+	fakeClient := fake.NewSimpleClientset(objects...)
+
+	// Setup JobExecutor
+	ex := JobExecutor{
+		Job: config.Job{
+			Name: "job-2",
+		},
+		clientSet:        fakeClient,
+		deletionStrategy: "default", // or empty
+	}
+
+	// Execute GC
+	ex.gc(ctx, nil)
+
+	// Wait for deletion (mock client deletes immediately but good to be safe)
+	// In fake client, delete is crucial.
+	// The gc function uses `CleanupNamespacesByLabel` which uses `Delete` and then `waitForDeleteNamespaces`.
+	// We expect the namespace to be gone.
+
+	// Verify namespace is deleted
+	_, err := fakeClient.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+	assert.Error(t, err, "Namespace SHOULD be deleted when deletionStrategy is default")
+	assert.True(t, true, "Namespace not found error expected")
+}


### PR DESCRIPTION
This PR fixes an issue where the `gvr` deletion strategy was deleting namespaces created by kube-burner.

According to the documentation and expected behavior:
- `default` deletion strategy deletes the entire namespace
- `gvr` deletion strategy should only delete objects within namespaces, not the namespace itself

The current behavior was incorrectly deleting namespaces even when `gvr` was selected.  
This change ensures that namespaces are preserved when using the `gvr` deletion strategy.

To prevent regressions, unit tests were added to explicitly verify:
- namespaces are **preserved** when `deletionStrategy = gvr`
- namespaces are **deleted** when `deletionStrategy = default`

All tests pass successfully.

Issue: #1008