### PR TITLE
job: preserve watcher stop errors when aggregating errs

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -208,7 +208,7 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 				measurementsInstance = nil
 			}
 			watcherStopErrs := watcherManager.StopAll()
-			slices.Concat(errs, watcherStopErrs)
+			errs = slices.Concat(errs, watcherStopErrs)
 			if jobExecutor.GC {
 				jobExecutor.gc(ctx, nil)
 			}


### PR DESCRIPTION
Fixes a bug where watcher stop errors were dropped because the return value of
slices.Concat was not assigned. The aggregated error slice now correctly
includes watcher cleanup failures.

Fixes #1133 