### PR TITLE
docs: clarify DeletionStrategy gvr behavior

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -99,7 +99,6 @@ created during a run are cleaned up.
 ### default
 - Deletes all namespaced resources created by kube-burner
 - Deletes the namespaces created by kube-burner, hence their child objects too
-- Namespace deletion is performed after resources are removed
 - Deletes cluster-scoped objects created by kube-burner
 
 ### gvr


### PR DESCRIPTION
Clarifies the intended behavior of `DeletionStrategy`.

`gvr` deletes only namespaced resources created by kube-burner
Namespaces are not deleted when using `gvr` (by design)
 Namespace deletion remains exclusive to the `default` strategy

Documentation  Issue: #1008