### PR TITLE
fix: prefer ingress IP over hostname for LoadBalancer services

### DIFF
--- a/pkg/measurements/service_latency.go
+++ b/pkg/measurements/service_latency.go
@@ -140,9 +140,9 @@ func (s *serviceLatency) handleCreateSvc(obj any) {
 				case corev1.ServiceTypeLoadBalancer:
 					for _, ingress := range svc.Status.LoadBalancer.Ingress {
 						if ingress.IP != "" {
-							ips = append(ips, ingress.Hostname)
-						} else {
 							ips = append(ips, ingress.IP)
+						} else if ingress.Hostname != "" {
+							ips = append(ips, ingress.Hostname)
 						}
 					}
 					port = specPort.Port


### PR DESCRIPTION
Fixes the LoadBalancer ingress address selection in service latency handling.

When iterating over `svc.Status.LoadBalancer.Ingress`, the logic previously used
`ingress.Hostname` when an IP was present and fell back to `ingress.IP` when it
was empty. This resulted in incorrect or empty addresses being used for latency
checks.

The logic is corrected to:
- prefer `ingress.IP` when available
- fall back to `ingress.Hostname` only when IP is empty
- avoid appending empty values

The change is minimal and limited to the affected code path.
Fixes #1139 