### PR TITLE
Fix GVK shadowing when resolving WaitOptions

### DIFF
--- a/pkg/burner/object.go
+++ b/pkg/burner/object.go
@@ -58,12 +58,12 @@ func newObject(obj config.Object, mapper *restmapper.DeferredDiscoveryRESTMapper
 		if obj.WaitOptions.APIVersion == "" {
 			obj.WaitOptions.APIVersion = obj.APIVersion
 		}
-		gvk = schema.FromAPIVersionAndKind(obj.WaitOptions.APIVersion, obj.WaitOptions.Kind)
-		mapping, err = mapper.RESTMapping(gvk.GroupKind())
+		waitGVK := schema.FromAPIVersionAndKind(obj.WaitOptions.APIVersion, obj.WaitOptions.Kind)
+		waitMapping, err := mapper.RESTMapping(waitGVK.GroupKind())
 		if err != nil {
 			log.Fatal(err)
 		}
-		waitGVR = &mapping.Resource
+		waitGVR = &waitMapping.Resource
 	}
 
 	o := object{


### PR DESCRIPTION
Fixes an issue where the primary object’s GVK was overwritten while resolving WaitOptions.
This caused the primary mapping.Resource to incorrectly point to the wait object’s GVR.

The fix introduces separate variables for wait-specific GVK and mapping, ensuring:
1 . the primary object’s GVK and GVR remain unchanged
2 . the wait logic uses the correct wait-specific GVR

Fixes #1141 