### PR TITLE
fix(makefile): respect PREFIX and DESTDIR in install target

### DIFF
--- a/.github/workflows/test-k8s-ppc64le.yml
+++ b/.github/workflows/test-k8s-ppc64le.yml
@@ -39,13 +39,13 @@ jobs:
 
     - name: Download kubectl binary
       run: |
-        wget https://dl.k8s.io/${K8S_VERSION}/bin/linux/ppc64le/kubectl -O /tmp/kubectl --no-verbose
-        chmod +x /tmp/kubectl
+        wget https://dl.k8s.io/${K8S_VERSION}/bin/linux/ppc64le/kubectl -O ${{ runner.temp }}/kubectl --no-verbose
+        chmod +x ${{ runner.temp }}/kubectl
 
     - name:  Build and install kube-burner binary.
       run: |
         make build
-        cp bin/ppc64le/kube-burner /tmp
+        cp bin/ppc64le/kube-burner ${{ runner.temp }}
 
     - name: Build container images
       run: make images
@@ -54,7 +54,7 @@ jobs:
 
     - name: Execute tests
       run: |
-        export PATH=${PATH}:/tmp/
+        export PATH=${PATH}:${{ runner.temp }}/
         make test-k8s
       env:
         TERM: linux
@@ -63,5 +63,5 @@ jobs:
     - name: Clean up
       run: |
         rm -rf ${{ github.workspace }}/*
-        rm -rf /tmp/tmp*
-        rm /tmp/kube-burner
+        rm -rf ${{ runner.temp }}/tmp*
+        rm ${{ runner.temp }}/kube-burner

--- a/.github/workflows/test-k8s.yml
+++ b/.github/workflows/test-k8s.yml
@@ -49,7 +49,7 @@ jobs:
       uses: actions/download-artifact@v7
       with:
         name: kube-burner
-        path: /tmp/
+        path: ${{ runner.temp }}/
 
     - name: Install bats
       uses: bats-core/bats-action@3.0.1
@@ -62,7 +62,7 @@ jobs:
 
     - name: Execute Tests
       run: |
-        chmod +x /tmp/kube-burner
+        chmod +x ${{ runner.temp }}/kube-burner
         make test-k8s
       env:
         TERM: linux
@@ -70,4 +70,4 @@ jobs:
         KIND_VERSION: v0.19.0
         K8S_VERSION: ${{matrix.k8s-version}}
         PERFSCALE_PROD_ES_SERVER: ${{ secrets.PERFSCALE_PROD_ES_SERVER }}
-        TEST_BINARY: /tmp/kube-burner
+        TEST_BINARY: ${{ runner.temp }}/kube-burner

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -7,7 +7,11 @@ set -euo pipefail
 
 # Configuration
 REPO="kube-burner/kube-burner"
-INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin/}"
+if [[ -n "${PREFIX}" ]]; then
+  INSTALL_DIR="${DESTDIR}${PREFIX}/bin"
+else
+  INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin/}"
+fi
 
 # Detect OS
 detect_os() {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -6,7 +6,15 @@ KIND_VERSION=${KIND_VERSION:-v0.19.0}
 K8S_VERSION=${K8S_VERSION:-v1.31.0}
 OCI_BIN=${OCI_BIN:-podman}
 ARCH=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
-KUBE_BURNER=${KUBE_BURNER:-kube-burner}
+if [[ -n "${KUBE_BURNER}" ]]; then
+  : # KUBE_BURNER is already set
+elif [[ -n "${PREFIX}" ]] && [[ -x "${DESTDIR}${PREFIX}/bin/kube-burner" ]]; then
+  KUBE_BURNER="${DESTDIR}${PREFIX}/bin/kube-burner"
+elif [[ -x "${DESTDIR}/usr/local/bin/kube-burner" ]]; then
+  KUBE_BURNER="${DESTDIR}/usr/local/bin/kube-burner"
+else
+  KUBE_BURNER=$(command -v kube-burner || echo "kube-burner")
+fi
 KIND_YAML=${KIND_YAML:-kind.yml}
 KUBEVIRT_CR=${KUBEVIRT_CR:-objectTemplates/kubevirt-cr.yaml}
 


### PR DESCRIPTION
This change updates the install target to use PREFIX and DESTDIR instead of hardcoding /usr/bin, making installs work on macOS and in non-root environments.

Fixes  #1148