### PR TITLE
fix: make clean removes entire bin directory to prevent stale artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ lint:
 	@echo "pre-commit executed."
 
 clean:
-	test ! -e $(BIN_DIR) || rm -Rf $(BIN_PATH)
+	rm -rf $(BIN_DIR)
 
 install:
 	cp $(BIN_PATH) /usr/bin/$(BIN_NAME)


### PR DESCRIPTION
The current clean target only removes a specific binary path, which can leave stale build artifacts inside the bin/ directory. This may result in cross-architecture build confusion, incorrect test behavior, or inconsistent CI results when switching between builds.

This change updates the clean target to remove the entire bin/ directory, ensuring all generated binaries and build outputs are deleted. After running make clean, the repository is restored to a fully clean, pre-build state.

Fixes #1156 