### PR TITLE
perf: limit Makefile source discovery to cmd/ and pkg/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ HARDENED_CGO_LDFLAGS = -linkmode=external -extldflags "-Wl,-z,relro,-z,now"
 
 GIT_COMMIT = $(shell git rev-parse HEAD)
 VERSION ?= $(shell hack/tag_name.sh)
-SOURCES := $(shell find . -type f -name "*.go")
+SOURCES := $(shell find cmd pkg -type f -name "*.go")
 BUILD_DATE = $(shell date '+%Y-%m-%d-%H:%M:%S')
 KUBE_BURNER_VERSION= github.com/cloud-bulldozer/go-commons/v2/version
 


### PR DESCRIPTION
## Type of change

 - Optimization


Limit Go source discovery in the Makefile to cmd/ and pkg/ instead of recursively scanning the entire repository.

Previously, find . -type f -name "*.go" traversed the full tree, including directories such as vendor/, which adds unnecessary overhead and can lead to argument expansion risks as the repository grows.

This change scopes discovery to the actual Go source directories without altering build behavior or targets.

Fix #1159 