### PR TITLE
Docs: fix objectWait default value to match boolean type

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -127,7 +127,7 @@ This section contains the list of jobs `kube-burner` will execute. Each job can 
 | `defaultMissingKeysWithZero` | Stops templates from exiting with an error when a missing key is found, meaning users will have to ensure templates hand missing keys | Boolean  | false    |
 | `executionMode`              | Job execution mode. More details at [execution modes](#execution-modes)                                                               | String   | parallel |
 | `objectDelay`                | How long to wait between each object in a job                                                                                         | Duration | 0s       |
-| `objectWait`                 | Wait for each object to complete before processing the next one - not for Create jobs                                                 | Boolean  | 0s       |
+| `objectWait`                 | Wait for each object to complete before processing the next one - not for Create jobs                                                 | Boolean  | false    |
 | `metricsAggregate`           | Aggregate the metrics collected for this job with those of the next one                                                               | Boolean  | false    |
 | `metricsClosing`             | To define when the metrics collection should stop. More details at [MetricsClosing](#MetricsClosing)                                  | String   | afterJobPause |
 


### PR DESCRIPTION
Fixes a documentation inconsistency in configuration.md.

objectWait is declared as a Boolean, but the default value was documented as 0s (duration).
This updates the default to false so it correctly matches the Boolean type and the actual implementation.

Fixes #1161 