### PR TITLE
Fix: finalize and index measurements on benchmark timeout 

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -270,7 +270,9 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 		errs = append(errs, err)
 		rc = rcTimeout
 		if measurementsInstance != nil {
-			measurementsInstance.Stop()
+			if err := measurementsInstance.Stop(); err != nil {
+				errs = append(errs, err)
+			}
 			if len(metricsScraper.IndexerList) > 0 {
 				measurementsInstance.Index(measurementsJobName, metricsScraper.IndexerList)
 			}


### PR DESCRIPTION
When a benchmark times out, measurement collectors could still be running before indexing occurs. This change ensures that on timeout all measurements are stopped and finalized before being indexed. Normal execution flow remains unchanged.

Fixes #1155 