### PR TITLE
Fix RunOnce guard when iterationStart is non-zero

### DIFF
--- a/pkg/burner/create.go
+++ b/pkg/burner/create.go
@@ -159,10 +159,11 @@ func (ex *JobExecutor) RunCreateJob(ctx context.Context, iterationStart, iterati
 			}
 			ex.objects[objectIndex].LabelSelector = kbLabels
 			if obj.RunOnce {
-				if i == 0 {
+				if !obj.hasRun {
 					// this executes only once during the first iteration of an object
 					log.Debugf("RunOnce set to %s, so creating object once", obj.ObjectTemplate)
 					ex.replicaHandler(ctx, kbLabels, obj, ns, i, &wg)
+					obj.hasRun = true
 				}
 			} else {
 				ex.replicaHandler(ctx, kbLabels, obj, ns, i, &wg)

--- a/pkg/burner/object.go
+++ b/pkg/burner/object.go
@@ -35,6 +35,7 @@ type object struct {
 	namespace     string
 	namespaced    bool
 	ready         bool
+	hasRun        bool
 	documentIndex int
 }
 


### PR DESCRIPTION
RunOnce execution was guarded by i == 0, assuming iterations always start at zero.
When iterationStart is non-zero (e.g., resume or churn paths), the RunOnce block was silently skipped.

This change makes RunOnce state-driven so it executes exactly once per object regardless of the iteration offset.

FIxes #1145
