### PR TITLE
Do not add annotations or labels to preload namespaces

### DIFF
--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -96,7 +96,9 @@ func preLoadImages(ctx context.Context, job JobExecutor, clientSet kubernetes.In
 	if err := waitForImagePull(preloadCtx, clientSet, desired, len(imageList)); err != nil {
 		return fmt.Errorf("pre-load: %v", err)
 	}
-	util.CleanupNamespacesByLabel(preloadCtx, clientSet, fmt.Sprintf("kubernetes.io/metadata.name=%s", preLoadNs))
+	if err := util.CleanupNamespacesByLabel(preloadCtx, clientSet, fmt.Sprintf("kubernetes.io/metadata.name=%s", preLoadNs)); err != nil {
+		return fmt.Errorf("pre-load: %v", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Type of change

- Refactor
- New feature
- Bug fix
- Optimization
- Documentation
- CI

## Description

There're situations that when labeling or annotating a namespace can lead to timeouts in the preload stage. I've observed this issue when using [ovn-k UDN objects](https://ovn-kubernetes.io/features/user-defined-networks/user-defined-networks/#user-facing-api-changes), when a namespace is labeled with `k8s.ovn.org/primary-user-defined-network` , every pod created within that namespace expects a UDN object to be present in it, and if it doesn't exist,  it gets stuck in the `ContainersCreating` phase, which doesn't pull the images.

This PR prevents adding namespaceLabels or namespaceAnnotations to the preload namespace going forward.
