### PR TITLE
Adding AI Policy

### DIFF
--- a/docs/contributing/ai-policy.md
+++ b/docs/contributing/ai-policy.md
@@ -1,0 +1,69 @@
+![kube-burner logo](../media/logos/kube-burner-logo-mini.png)
+
+# kube-burner LLM (AI) Contribution Policy
+
+Large language models (LLMs) such as ChatGPT, Copilot, and Claude can help contributors work faster. They can also introduce risk when output is submitted without careful review.
+
+Kube-burner values clear communication, maintainable code, and high review quality. This policy defines expectations when AI tools are used in kube-burner repositories and community spaces.
+
+## Direct Communication
+
+Do not post raw or copy-pasted LLM output as your own communication.
+
+This applies to:
+
+- GitHub issues and issue comments
+- Pull request descriptions and review comments
+- Commit messages
+- Slack, discussions, and other project communication channels
+- Security and vulnerability reports
+
+Write in your own words and make sure you understand what you submit.
+
+### Exceptions
+
+- Translation help is allowed. If you used an LLM for translation, say so clearly (for example: "Translated with an LLM from <language>").
+- Maintainer-managed automation or bots may suggest changes. These suggestions are not authoritative and must still be reviewed by humans.
+
+Repeated violations may result in closed submissions or removal from project spaces.
+
+## Code Contributions Assisted by LLMs
+
+Using LLMs for coding is allowed, but responsibility remains with the contributor.
+
+### Requirements
+
+- Follow all project contribution guidance in [CONTRIBUTING.md](https://github.com/kube-burner/kube-burner/blob/main/CONTRIBUTING.md)
+- Keep changes focused, minimal, and easy to review
+- Match existing style, formatting, and structure
+- Remove unnecessary noise (unused files, generated metadata, unrelated edits)
+- Ensure your change builds and passes relevant tests before requesting review
+- Test the behavior you changed
+
+### Ownership and Understanding
+
+You must:
+
+- Review generated code before submitting
+- Explain what changed and why in your own words
+- Be able to discuss implementation details during review
+
+Submissions that are clearly not understood by the author may be rejected.
+
+## Responding to Review Feedback
+
+Do not blindly paste review comments into an LLM and submit the response unchanged.
+
+Contributors are expected to:
+
+- Respond thoughtfully in their own words
+- Make targeted updates that address the feedback
+- Understand and validate each requested change
+
+## Maintainer Discretion
+
+Maintainers may decline changes that are difficult to review, overly large, poorly structured, or repeatedly low quality, regardless of whether AI tools were used.
+
+## Golden Rule
+
+Use LLMs as assistants, not as substitutes for understanding, accountability, and craftsmanship.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -3,6 +3,10 @@
 If you want to contribute to kube-burner, you can do so by submitting a Pull Request, Issue or starting a Discussion.
 You can also reach us out in the `#kube-burner` channel of the [kubernetes slack](https://kubernetes.slack.com/messages/kube-burner).
 
+## Policies
+
+- [LLM (AI) Contribution Policy](ai-policy.md)
+
 ## CI and Linting
 
 For running pre-commit checks on your code before committing code and opening a PR, you can use the `pre-commit run` functionality.  See [CI docs](https://kube-burner.github.io/kube-burner/latest/contributing/pullrequest/#running-local-pre-commit) for more information on running pre-commits.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - Alerting: observability/alerting.md
 - Contributing:
   - contributing/index.md
+  - AI Policy: contributing/ai-policy.md
   - GitHub Workflows:
     - contributing/pullrequest.md
     - contributing/release.md


### PR DESCRIPTION
## Type of change
- Documentation

## Description
Adding AI policy for gate-keeping incoming PRs and Issues.

## Related Tickets & Documents
- Closes # PR and Issues that are unclear and not properly raised.
