### PR TITLE
Fail netpol test if latency is higher than configured threshold

### DIFF
--- a/pkg/measurements/metrics/metrics.go
+++ b/pkg/measurements/metrics/metrics.go
@@ -54,7 +54,7 @@ func CheckThreshold(thresholds []types.LatencyThreshold, quantiles []any) error 
 				v := r.FieldByName(phase.Metric).Int()
 				if v > phase.Threshold.Milliseconds() {
 					latency := float32(v) / 1000
-					err := fmt.Errorf("podLatency: %s %s latency (%.2fs) higher than configured threshold: %v", phase.Metric, phase.ConditionType, latency, phase.Threshold)
+					err := fmt.Errorf("%s: %s %s latency (%.2fs) higher than configured threshold: %v", pq.(LatencyQuantiles).MetricName, phase.Metric, phase.ConditionType, latency, phase.Threshold)
 					errs = append(errs, err)
 				}
 			}

--- a/pkg/measurements/netpol_latency.go
+++ b/pkg/measurements/netpol_latency.go
@@ -582,20 +582,12 @@ func (n *netpolLatency) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer func() {
 		cancel()
-		n.stopWatchers()
 	}()
 	kutil.CleanupNamespacesByLabel(ctx, n.ClientSet, fmt.Sprintf("kubernetes.io/metadata.name=%s", networkPolicyProxy))
-	n.normalizeMetrics()
-	for _, q := range n.LatencyQuantiles {
-		pq := q.(metrics.LatencyQuantiles)
-		// Divide nanoseconds by 1e6 to get milliseconds
-		log.Infof("%s: %s 50th: %d 99th: %d max: %d avg: %d", n.JobConfig.Name, pq.QuantileName, pq.P50, pq.P99, pq.Max, pq.Avg)
-
-	}
-	return nil
+	return n.StopMeasurement(n.normalizeMetrics, n.getLatency)
 }
 
-func (n *netpolLatency) normalizeMetrics() {
+func (n *netpolLatency) normalizeMetrics() float64 {
 	var latencies []float64
 	var minLatencies []float64
 	sLen := 0
@@ -607,18 +599,14 @@ func (n *netpolLatency) normalizeMetrics() {
 		n.NormLatencies = append(n.NormLatencies, metric)
 		return true
 	})
-	calcSummary := func(name string, inputLatencies []float64) metrics.LatencyQuantiles {
-		latencySummary := metrics.NewLatencySummary(inputLatencies, name)
-		latencySummary.UUID = n.Uuid
-		latencySummary.Timestamp = time.Now().UTC()
-		latencySummary.Metadata = n.Metadata
-		latencySummary.MetricName = netpolLatencyQuantilesMeasurement
-		latencySummary.JobName = n.JobConfig.Name
-		return latencySummary
-	}
-	if sLen > 0 {
-		n.LatencyQuantiles = append(n.LatencyQuantiles, calcSummary("Ready", latencies))
-		n.LatencyQuantiles = append(n.LatencyQuantiles, calcSummary("minReady", minLatencies))
+	return 0.0
+}
+
+func (n *netpolLatency) getLatency(normLatency any) map[string]float64 {
+	netpolMetric := normLatency.(netpolMetric)
+	return map[string]float64{
+		"Ready":    float64(netpolMetric.ReadyLatency),
+		"MinReady": float64(netpolMetric.MinReadyLatency),
 	}
 }
 


### PR DESCRIPTION
network policy latency measurement code should call StopMeasurement which fails the test if the netpol latency is higher than the configured threshold

Also CheckThreshold() is modified to print the metric name instead of hard coded podLatency

Tested and able to see the error when netpol latency is less than the configred threshold i.e

kube-burner-ocp network-policy --except-rules=0 --netpol-ready-threshold=2000ms --pods-per-namespace 10 --netpol-per-namespace 20 --local-pods 10 --single-ports 5 --port-ranges 5 --remotes-namespaces 5 --remotes-pods 5 --cidrs 5 --iterations=240

time="2026-03-11 06:54:01" level=info msg="network-policy-perf: Ready 99th: 4815 ms max: 7054 ms avg: 2952 ms" file="base_measurement.go:127"
time="2026-03-11 06:54:01" level=info msg="network-policy-perf: MinReady 99th: 1673 ms max: 2937 ms avg: 855 ms" file="base_measurement.go:127"
time="2026-03-11 06:54:01" level=error msg="netpolLatencyQuantilesMeasurement: P99 Ready latency (4.82s) higher than configured threshold: 2s" file="job.go:198"
