### PR TITLE
Cleanup stale runs before running the first one

### DIFF
--- a/pkg/burner/job.go
+++ b/pkg/burner/job.go
@@ -96,7 +96,14 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 			return
 		}
 
-		// Iterate job list
+		// Cleanup previous runs
+		for _, jobExecutor := range jobExecutors {
+			if jobExecutor.JobType == config.CreationJob && jobExecutor.Cleanup {
+				log.Infof("Cleaning up previous runs for job: %s", jobExecutor.Name)
+				jobExecutor.gc(ctx, nil)
+			}
+		}
+		// Run jobs
 		for jobExecutorIdx, jobExecutor := range jobExecutors {
 			executedJobs = append(executedJobs, prometheus.Job{
 				Start:     time.Now().UTC(),
@@ -117,10 +124,6 @@ func Run(configSpec config.Spec, kubeClientProvider *config.KubeClientProvider, 
 			}
 			log.Infof("Triggering job: %s", jobExecutor.Name)
 			if jobExecutor.JobType == config.CreationJob {
-				if jobExecutor.Cleanup {
-					log.Info("Cleaning up previous runs")
-					jobExecutor.gc(ctx, nil)
-				}
 				if config.IsChurnEnabled(jobExecutor.Job) {
 					log.Info("Churning enabled")
 					log.Infof("Churn cycles: %v", jobExecutor.ChurnConfig.Cycles)


### PR DESCRIPTION
## Type of change

- Optimization

## Description

To keep old data cleanup separate from the job runtime, we should perform this operation before triggering any jobs.
