### PR TITLE
Pod latency timestamp fixes

### DIFF
--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -84,8 +84,9 @@ type podMetric struct {
 
 type podLatency struct {
 	BaseMeasurement
-	eventLister    lcorev1.EventLister
-	stopInformerCh chan struct{}
+	eventLister     lcorev1.EventLister
+	eventInformerCh chan struct{}
+	handlerWg       sync.WaitGroup
 }
 
 type podLatencyMeasurementFactory struct {
@@ -108,6 +109,8 @@ func (plmf podLatencyMeasurementFactory) NewMeasurement(jobConfig *config.Job, c
 }
 
 func (p *podLatency) handleCreatePod(obj any) {
+	p.handlerWg.Add(1)
+	defer p.handlerWg.Done()
 	pod, err := util.ConvertAnyToTyped[corev1.Pod](obj)
 	if err != nil {
 		log.Errorf("failed to convert to Pod: %v", err)
@@ -128,6 +131,8 @@ func (p *podLatency) handleCreatePod(obj any) {
 }
 
 func (p *podLatency) handleUpdatePod(obj any) {
+	p.handlerWg.Add(1)
+	defer p.handlerWg.Done()
 	pod, err := util.ConvertAnyToTyped[corev1.Pod](obj)
 	if err != nil {
 		log.Errorf("failed to convert to Pod: %v", err)
@@ -248,9 +253,9 @@ func (p *podLatency) Start(measurementWg *sync.WaitGroup) error {
 	if err := eventInformer.SetTransform(eventTransformFunc()); err != nil {
 		log.Warnf("failed to set event transform: %v", err)
 	}
-	p.stopInformerCh = make(chan struct{})
-	go eventInformer.Run(p.stopInformerCh)
-	if !cache.WaitForCacheSync(p.stopInformerCh, eventInformer.HasSynced) {
+	p.eventInformerCh = make(chan struct{})
+	go eventInformer.Run(p.eventInformerCh)
+	if !cache.WaitForCacheSync(p.eventInformerCh, eventInformer.HasSynced) {
 		return fmt.Errorf("failed to sync event informer cache")
 	}
 	p.eventLister = lcorev1.NewEventLister(eventInformer.GetIndexer())
@@ -324,8 +329,14 @@ func (p *podLatency) Collect(measurementWg *sync.WaitGroup) {
 
 // Stop stops podLatency measurement
 func (p *podLatency) Stop() error {
-	close(p.stopInformerCh)
-	return p.StopMeasurement(p.normalizeMetrics, p.getLatency)
+	// Since handlers may still be querying the event lister,
+	// Close the event informer channel to prevent new items from being processed.
+	close(p.eventInformerCh)
+	// Wait for any in-flight handlers to finish.
+	p.handlerWg.Wait()
+	// StopMeasurement stops the watchers first, preventing new handler invocations.
+	err := p.StopMeasurement(p.normalizeMetrics, p.getLatency)
+	return err
 }
 
 func (p *podLatency) normalizeMetrics() float64 {

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -86,7 +86,6 @@ type podLatency struct {
 	BaseMeasurement
 	eventLister     lcorev1.EventLister
 	eventInformerCh chan struct{}
-	handlerWg       sync.WaitGroup
 }
 
 type podLatencyMeasurementFactory struct {
@@ -109,8 +108,6 @@ func (plmf podLatencyMeasurementFactory) NewMeasurement(jobConfig *config.Job, c
 }
 
 func (p *podLatency) handleCreatePod(obj any) {
-	p.handlerWg.Add(1)
-	defer p.handlerWg.Done()
 	pod, err := util.ConvertAnyToTyped[corev1.Pod](obj)
 	if err != nil {
 		log.Errorf("failed to convert to Pod: %v", err)
@@ -131,8 +128,6 @@ func (p *podLatency) handleCreatePod(obj any) {
 }
 
 func (p *podLatency) handleUpdatePod(obj any) {
-	p.handlerWg.Add(1)
-	defer p.handlerWg.Done()
 	pod, err := util.ConvertAnyToTyped[corev1.Pod](obj)
 	if err != nil {
 		log.Errorf("failed to convert to Pod: %v", err)
@@ -189,7 +184,7 @@ func (p *podLatency) getScheduledTimeFromEvent(pod *corev1.Pod) time.Time {
 			}
 		}
 		return false, nil
-	}, 1*time.Second, 2, 0, 1*time.Minute)
+	}, 100*time.Millisecond, 2, 0, time.Minute)
 	if err != nil {
 		log.Warnf("failed to get scheduled of pod %s/%s time from event: %v", pod.Namespace, pod.Name, err)
 	}
@@ -226,7 +221,7 @@ func (p *podLatency) getStartedTimeFromEvent(pod *corev1.Pod) time.Time {
 			return false, nil
 		}
 		return true, nil
-	}, time.Second, 5, 0, 1*time.Minute)
+	}, 100*time.Millisecond, 5, 0, time.Minute)
 	if err != nil {
 		log.Warnf("failed to get started of pod %s/%s time from event: %v", pod.Namespace, pod.Name, err)
 	}
@@ -329,14 +324,8 @@ func (p *podLatency) Collect(measurementWg *sync.WaitGroup) {
 
 // Stop stops podLatency measurement
 func (p *podLatency) Stop() error {
-	// Since handlers may still be querying the event lister,
-	// Close the event informer channel to prevent new items from being processed.
-	close(p.eventInformerCh)
-	// Wait for any in-flight handlers to finish.
-	p.handlerWg.Wait()
-	// StopMeasurement stops the watchers first, preventing new handler invocations.
-	err := p.StopMeasurement(p.normalizeMetrics, p.getLatency)
-	return err
+	defer close(p.eventInformerCh)
+	return p.StopMeasurement(p.normalizeMetrics, p.getLatency)
 }
 
 func (p *podLatency) normalizeMetrics() float64 {

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -55,8 +55,6 @@ var (
 		config.PatchJob:    {},
 		config.DeletionJob: {},
 	}
-	// eventRetryDelays are backoff delays when event is not yet in the lister (high load).
-	eventRetryDelays = []time.Duration{200 * time.Millisecond, 500 * time.Millisecond, time.Second}
 )
 
 type podMetric struct {
@@ -176,23 +174,28 @@ func (p *podLatency) handleUpdatePod(obj any) {
 // getScheduledTimeFromEvent returns scheduled time in microseconds precision from event.
 // Retries with backoff when the event is not yet in the lister (e.g. under high load).
 func (p *podLatency) getScheduledTimeFromEvent(pod *corev1.Pod) time.Time {
-	for _, delay := range eventRetryDelays {
+	var timestamp time.Time
+	err := util.RetryWithExponentialBackOff(func() (bool, error) {
 		eventList, _ := p.eventLister.List(labels.Everything())
 		for _, event := range eventList {
 			if event.InvolvedObject.UID == pod.UID && event.Reason == "Scheduled" {
-				return event.EventTime.Time
+				timestamp = event.EventTime.Time
+				return true, nil
 			}
 		}
-		time.Sleep(delay)
+		return false, nil
+	}, 1*time.Second, 5, 0, 1*time.Minute)
+	if err != nil {
+		log.Warnf("failed to get scheduled of pod %s/%s time from event: %v", pod.Namespace, pod.Name, err)
 	}
-	return time.Time{}
+	return timestamp
 }
 
 // getStartedTimeFromEvent returns the timestamp of the latest container started event in the pod.
 // Retries with backoff when the event is not yet in the lister (e.g. under high load).
 func (p *podLatency) getStartedTimeFromEvent(pod *corev1.Pod) time.Time {
 	var timestamp time.Time
-	for _, delay := range eventRetryDelays {
+	err := util.RetryWithExponentialBackOff(func() (bool, error) {
 		eventList, _ := p.eventLister.List(labels.Everything())
 		for _, event := range eventList {
 			if event.InvolvedObject.UID == pod.UID && event.Reason == "Started" {
@@ -215,10 +218,12 @@ func (p *podLatency) getStartedTimeFromEvent(pod *corev1.Pod) time.Time {
 			}
 		}
 		if timestamp.IsZero() {
-			time.Sleep(delay)
-		} else {
-			break
+			return false, nil
 		}
+		return true, nil
+	}, time.Second, 5, 0, 1*time.Minute)
+	if err != nil {
+		log.Warnf("failed to get started of pod %s/%s time from event: %v", pod.Namespace, pod.Name, err)
 	}
 	return timestamp
 }

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -184,7 +184,7 @@ func (p *podLatency) getScheduledTimeFromEvent(pod *corev1.Pod) time.Time {
 			}
 		}
 		return false, nil
-	}, 1*time.Second, 5, 0, 1*time.Minute)
+	}, 1*time.Second, 2, 0, 1*time.Minute)
 	if err != nil {
 		log.Warnf("failed to get scheduled of pod %s/%s time from event: %v", pod.Namespace, pod.Name, err)
 	}

--- a/pkg/measurements/pod_latency.go
+++ b/pkg/measurements/pod_latency.go
@@ -55,6 +55,8 @@ var (
 		config.PatchJob:    {},
 		config.DeletionJob: {},
 	}
+	// eventRetryDelays are backoff delays when event is not yet in the lister (high load).
+	eventRetryDelays = []time.Duration{200 * time.Millisecond, 500 * time.Millisecond, time.Second}
 )
 
 type podMetric struct {
@@ -171,36 +173,51 @@ func (p *podLatency) handleUpdatePod(obj any) {
 	}
 }
 
-// getScheduledTimeFromEvent returns scheduled time in microseconds precission from event
+// getScheduledTimeFromEvent returns scheduled time in microseconds precision from event.
+// Retries with backoff when the event is not yet in the lister (e.g. under high load).
 func (p *podLatency) getScheduledTimeFromEvent(pod *corev1.Pod) time.Time {
-	eventList, _ := p.eventLister.List(labels.Everything())
-	for _, event := range eventList {
-		if event.InvolvedObject.UID == pod.UID && event.Reason == "Scheduled" {
-			return event.EventTime.Time
+	for _, delay := range eventRetryDelays {
+		eventList, _ := p.eventLister.List(labels.Everything())
+		for _, event := range eventList {
+			if event.InvolvedObject.UID == pod.UID && event.Reason == "Scheduled" {
+				return event.EventTime.Time
+			}
 		}
+		time.Sleep(delay)
 	}
 	return time.Time{}
 }
 
-// getStartedTimeFromEvent returns the timestamp of the latest container started event in the pod
+// getStartedTimeFromEvent returns the timestamp of the latest container started event in the pod.
+// Retries with backoff when the event is not yet in the lister (e.g. under high load).
 func (p *podLatency) getStartedTimeFromEvent(pod *corev1.Pod) time.Time {
 	var timestamp time.Time
-	eventList, _ := p.eventLister.List(labels.Everything())
-	for _, event := range eventList {
-		if event.InvolvedObject.UID == pod.UID && event.Reason == "Started" {
-			// The event name is in the format "podName.timestamp", where timestamp in hexadecimal format
-			// https://github.com/kubernetes/client-go/blob/v0.34.2/tools/record/event.go#L492
-			eventName := strings.Split(event.Name, ".")
-			eventTsInt, err := strconv.ParseInt(eventName[1], 16, 64)
-			if err != nil {
-				log.Warnf("failed to parse event timestamp: %v", err)
-				continue
+	for _, delay := range eventRetryDelays {
+		eventList, _ := p.eventLister.List(labels.Everything())
+		for _, event := range eventList {
+			if event.InvolvedObject.UID == pod.UID && event.Reason == "Started" {
+				// The event name is in the format "podName.timestamp", where timestamp is in hexadecimal format
+				// https://github.com/kubernetes/client-go/blob/v0.34.2/tools/record/event.go#L492
+				eventName := strings.Split(event.Name, ".")
+				if len(eventName) < 2 {
+					continue
+				}
+				eventTsInt, err := strconv.ParseInt(eventName[1], 16, 64)
+				if err != nil {
+					log.Warnf("failed to parse event timestamp: %v", err)
+					continue
+				}
+				eventTs := time.Unix(0, eventTsInt)
+				// In pods with multiple containers, pick the timestamp of the latest "Started" event observed
+				if timestamp.Before(eventTs) {
+					timestamp = eventTs
+				}
 			}
-			eventTs := time.Unix(0, eventTsInt)
-			// In pods with multiple containers, pick the timestamp of the latest "Started" event observed
-			if timestamp.Before(eventTs) {
-				timestamp = eventTs
-			}
+		}
+		if timestamp.IsZero() {
+			time.Sleep(delay)
+		} else {
+			break
 		}
 	}
 	return timestamp
@@ -309,6 +326,7 @@ func (p *podLatency) Stop() error {
 func (p *podLatency) normalizeMetrics() float64 {
 	totalPods := 0
 	erroredPods := 0
+	warningPods := 0
 
 	p.Metrics.Range(func(key, value any) bool {
 		m := value.(podMetric)
@@ -320,18 +338,12 @@ func (p *podLatency) normalizeMetrics() float64 {
 		// latencyTime should be always larger than zero, however, in some cases, it might be a
 		// negative value due to the precision of timestamp can only get to the level of second
 		errorFlag := 0
+		warningFlag := 0
 		m.ContainersReadyLatency = int(m.containersReady.Sub(m.Timestamp).Milliseconds())
 		if m.ContainersReadyLatency < 0 {
 			log.Tracef("ContainersReadyLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
 			errorFlag = 1
 			m.ContainersReadyLatency = 0
-		}
-
-		m.SchedulingLatency = int(m.scheduled.Sub(m.Timestamp).Milliseconds())
-		if m.SchedulingLatency < 0 {
-			log.Tracef("SchedulingLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
-			m.SchedulingLatency = 0
 		}
 
 		m.ReadyToStartContainersLatency = int(m.readyToStartContainers.Sub(m.Timestamp).Milliseconds())
@@ -354,17 +366,29 @@ func (p *podLatency) normalizeMetrics() float64 {
 			errorFlag = 1
 			m.PodReadyLatency = 0
 		}
+		// Both scheduling and containersStarted latencies are calculated from the event time, in high load scenarios,
+		// there might be a delay in the event time, so we print a warning message flag rather than returning an error
+		m.SchedulingLatency = int(m.scheduled.Sub(m.Timestamp).Milliseconds())
+		if m.SchedulingLatency < 0 {
+			log.Tracef("SchedulingLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
+			warningFlag = 1
+			m.SchedulingLatency = 0
+		}
 		m.ContainersStartedLatency = int(m.containersStarted.Sub(m.Timestamp).Milliseconds())
 		if m.ContainersStartedLatency < 0 {
 			log.Tracef("ContainersStartedLatency for pod %v falling under negative case. So explicitly setting it to 0", m.Name)
-			errorFlag = 1
+			warningFlag = 1
 			m.ContainersStartedLatency = 0
 		}
 		totalPods++
 		erroredPods += errorFlag
+		warningPods += warningFlag
 		p.NormLatencies = append(p.NormLatencies, m)
 		return true
 	})
+	if rate := float64(warningPods) / float64(totalPods); rate > 10 {
+		log.Warnf("something is wrong with system under test. containersStarted and scheduling latencies error rate was: %.2f", rate*100.0)
+	}
 	if totalPods == 0 {
 		return 0.0
 	}

--- a/test/k8s/kube-burner-measurements.yml
+++ b/test/k8s/kube-burner-measurements.yml
@@ -22,7 +22,7 @@ jobs:
     cleanup: true
     objects:
       - objectTemplate: objectTemplates/deployment.yml
-        replicas: 1
+        replicas: 3
         inputVars:
           containerImage: quay.io/cloud-bulldozer/sampleapp:latest
           envName: deployment-pod


### PR DESCRIPTION
## Type of change

- Bug fix
- Optimization

## Description

Changes wrt pod latency measurements:

- During high load conditions, there can be situations when events are not present in the eventLister cache immediately after they're created, this can lead both getScheduledTimeFromEvent() and getStartedTimeFromEvent() to retun 0 in those situations. Adding a ~simple retry improves their behavior~ retry exponential logic to wait for eventLister to be updated fixes this

- In addition, metrics calculated from events no longer return error when they are normalized, they log a warning message instead.

## Tests

After adding some extra debug messages:

Creating 600 pods @ 40 QPS, we can observe that the retry logic is triggered, indicating that the events were not in place at the time of reading them, the retry logic fixed these issues and now the data is collected properly

```
$ ~/labs/kube-burner/bin/amd64/kube-burner init -c kubelet-density.yml  --log-level=debug 2>&1  | grep retrying
time="2026-03-18 00:59:34" level=debug msg="no scheduled event found for pod kubelet-density-5, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:35" level=debug msg="no scheduled event found for pod kubelet-density-12, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:35" level=debug msg="no scheduled event found for pod kubelet-density-59, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:35" level=debug msg="no scheduled event found for pod kubelet-density-68, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:35" level=debug msg="no scheduled event found for pod kubelet-density-76, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:36" level=debug msg="no scheduled event found for pod kubelet-density-85, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:36" level=debug msg="no scheduled event found for pod kubelet-density-93, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:36" level=debug msg="no scheduled event found for pod kubelet-density-102, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:36" level=debug msg="no scheduled event found for pod kubelet-density-110, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:36" level=debug msg="no scheduled event found for pod kubelet-density-119, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:37" level=debug msg="no scheduled event found for pod kubelet-density-127, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:37" level=debug msg="no scheduled event found for pod kubelet-density-136, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:37" level=debug msg="no scheduled event found for pod kubelet-density-144, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:37" level=debug msg="no scheduled event found for pod kubelet-density-152, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:37" level=debug msg="no scheduled event found for pod kubelet-density-161, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:38" level=debug msg="no scheduled event found for pod kubelet-density-170, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:38" level=debug msg="no scheduled event found for pod kubelet-density-179, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:38" level=debug msg="no scheduled event found for pod kubelet-density-187, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:38" level=debug msg="no scheduled event found for pod kubelet-density-196, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:39" level=debug msg="no scheduled event found for pod kubelet-density-205, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:39" level=debug msg="no scheduled event found for pod kubelet-density-214, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:39" level=debug msg="no scheduled event found for pod kubelet-density-223, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:39" level=debug msg="no scheduled event found for pod kubelet-density-231, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:39" level=debug msg="no scheduled event found for pod kubelet-density-240, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:40" level=debug msg="no scheduled event found for pod kubelet-density-248, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:40" level=debug msg="no scheduled event found for pod kubelet-density-256, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:40" level=debug msg="no scheduled event found for pod kubelet-density-264, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:40" level=debug msg="no scheduled event found for pod kubelet-density-273, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:40" level=debug msg="no scheduled event found for pod kubelet-density-281, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:41" level=debug msg="no scheduled event found for pod kubelet-density-290, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:41" level=debug msg="no started event found for pod kubelet-density-134, retrying in 200ms" file="pod_latency.go:219"
time="2026-03-18 00:59:41" level=debug msg="no scheduled event found for pod kubelet-density-307, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:41" level=debug msg="no scheduled event found for pod kubelet-density-315, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:42" level=debug msg="no scheduled event found for pod kubelet-density-323, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:42" level=debug msg="no scheduled event found for pod kubelet-density-332, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:42" level=debug msg="no scheduled event found for pod kubelet-density-341, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:42" level=debug msg="no scheduled event found for pod kubelet-density-350, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:42" level=debug msg="no scheduled event found for pod kubelet-density-359, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:43" level=debug msg="no scheduled event found for pod kubelet-density-368, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:43" level=debug msg="no scheduled event found for pod kubelet-density-376, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:43" level=debug msg="no scheduled event found for pod kubelet-density-385, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:44" level=debug msg="no scheduled event found for pod kubelet-density-386, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:44" level=debug msg="no scheduled event found for pod kubelet-density-428, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:45" level=debug msg="no scheduled event found for pod kubelet-density-447, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:45" level=debug msg="no scheduled event found for pod kubelet-density-456, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:45" level=debug msg="no scheduled event found for pod kubelet-density-465, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:45" level=debug msg="no scheduled event found for pod kubelet-density-474, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:46" level=debug msg="no scheduled event found for pod kubelet-density-483, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:46" level=debug msg="no scheduled event found for pod kubelet-density-491, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:46" level=debug msg="no scheduled event found for pod kubelet-density-500, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:46" level=debug msg="no scheduled event found for pod kubelet-density-509, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:46" level=debug msg="no scheduled event found for pod kubelet-density-518, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:47" level=debug msg="no scheduled event found for pod kubelet-density-527, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:47" level=debug msg="no scheduled event found for pod kubelet-density-535, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:47" level=debug msg="no scheduled event found for pod kubelet-density-544, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:47" level=debug msg="no scheduled event found for pod kubelet-density-552, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:47" level=debug msg="no scheduled event found for pod kubelet-density-560, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:48" level=debug msg="no scheduled event found for pod kubelet-density-569, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:48" level=debug msg="no scheduled event found for pod kubelet-density-578, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:48" level=debug msg="no scheduled event found for pod kubelet-density-587, retrying in 200ms" file="pod_latency.go:186"
time="2026-03-18 00:59:48" level=debug msg="no scheduled event found for pod kubelet-density-596, retrying in 200ms" file="pod_latency.go:186"
```



## Related Tickets & Documents

- Related Issue #
- Closes #1189
