### PR TITLE
Reduce prometheus logging verbosity

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -207,7 +207,7 @@ func (p *Prometheus) runInstantQuery(query, metricName string, timestamp time.Ti
 		log.Warnf("Error found parsing result from query %s: %s", query, err)
 	}
 	if len(datapoints) == 0 {
-		log.Warnf("No datapoints returned from metric %s", metricName)
+		log.Warnf("No datapoints returned from metric %s for job %s at %s with query %q", metricName, job.JobConfig.Name, timestamp.Format(time.RFC3339), query)
 	}
 	return datapoints
 }

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -64,18 +64,17 @@ func (p *Prometheus) ScrapeJobsMetrics(jobList ...Job) error {
 			continue
 		}
 		for _, metricProfile := range p.MetricProfiles {
-			log.Infof("🔍 Endpoint: %v; profile: %v start: %v end: %v; job: %v, metricsClosing: %v", p.Endpoint,
-				metricProfile.name,
+			log.Infof("🔍 Collecting prometheus metrics for job %s; endpoint: %v; profile: %v ", eachJob.JobConfig.Name, p.Endpoint, metricProfile.name)
+			log.Infof("start: %v; end: %v; metrics closing: %v",
 				jobStart.Format(time.RFC3339),
 				jobEnd.Format(time.RFC3339),
-				eachJob.JobConfig.Name,
 				eachJob.JobConfig.MetricsClosing)
 			for _, metric := range metricProfile.metrics {
 				docsToIndex := make(map[string][]any, 2)
 				requiresInstant := false
 				t, _ := template.New("").Parse(metric.Query)
 				if err := t.Execute(&renderedQuery, vars); err != nil {
-					log.Warnf("Error rendering query: %v", err)
+					log.Warnf("Error rendering query from metric %s: %v", metric.MetricName, err)
 					continue
 				}
 				query := renderedQuery.String()
@@ -207,6 +206,9 @@ func (p *Prometheus) runInstantQuery(query, metricName string, timestamp time.Ti
 	if err = p.parseVector(metricName, query, job, v, &datapoints); err != nil {
 		log.Warnf("Error found parsing result from query %s: %s", query, err)
 	}
+	if len(datapoints) == 0 {
+		log.Warnf("No datapoints returned from metric %s", metricName)
+	}
 	return datapoints
 }
 
@@ -224,18 +226,21 @@ func (p *Prometheus) runRangeQuery(query, metricName string, jobStart, jobEnd ti
 	if err = p.parseMatrix(metricName, query, job, v, &datapoints); err != nil {
 		log.Warnf("Error found parsing result from query %s: %s", query, err)
 	}
+	if len(datapoints) == 0 {
+		log.Warnf("No datapoints returned from metric %s", metricName)
+	}
 	return datapoints
 }
 
 // Indexes datapoints to a specified indexer.
 func (p *Prometheus) indexDatapoints(docsToIndex map[string][]any) {
 	for metricName, docs := range docsToIndex {
-		log.Infof("Indexing [%d] documents from metric %s", len(docs), metricName)
+		log.Debugf("Indexing [%d] documents from metric %s", len(docs), metricName)
 		resp, err := (*p.indexer).Index(docs, indexers.IndexingOpts{MetricName: metricName})
 		if err != nil {
 			log.Error(err.Error())
 		} else {
-			log.Info(resp)
+			log.Debug(resp)
 		}
 	}
 }

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -17,6 +17,7 @@ package prometheus
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"math"
 	"text/template"
 	"time"
@@ -160,9 +161,7 @@ func (p *Prometheus) ReadProfile(location string, embedCfg *fileutils.EmbedConfi
 // Create metric creates metric to be indexed
 func (p *Prometheus) createMetric(query, metricName string, job Job, labels model.Metric, value model.SampleValue, timestamp time.Time, isInstant bool) metric {
 	metadata := map[string]any{}
-	for k, v := range p.metadata {
-		metadata[k] = v
-	}
+	maps.Copy(metadata, p.metadata)
 	if job.IncrementalLoadUUID != "" {
 		metadata["incrementalLoadUUID"] = job.IncrementalLoadUUID
 	}
@@ -235,7 +234,7 @@ func (p *Prometheus) runRangeQuery(query, metricName string, jobStart, jobEnd ti
 // Indexes datapoints to a specified indexer.
 func (p *Prometheus) indexDatapoints(docsToIndex map[string][]any) {
 	for metricName, docs := range docsToIndex {
-		log.Debugf("Indexing [%d] documents from metric %s", len(docs), metricName)
+		log.Infof("Indexing [%d] documents from metric %s", len(docs), metricName)
 		resp, err := (*p.indexer).Index(docs, indexers.IndexingOpts{MetricName: metricName})
 		if err != nil {
 			log.Error(err.Error())

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -227,7 +227,7 @@ func (p *Prometheus) runRangeQuery(query, metricName string, jobStart, jobEnd ti
 		log.Warnf("Error found parsing result from query %s: %s", query, err)
 	}
 	if len(datapoints) == 0 {
-		log.Warnf("No datapoints returned from metric %s for job %s in range %s - %s with query %q", metricName, job.Name, jobStart.Format(time.RFC3339), jobEnd.Format(time.RFC3339), query)
+		log.Warnf("No datapoints returned from metric %s for job %s in range %s - %s with query %q", metricName, job.JobConfig.Name, jobStart.Format(time.RFC3339), jobEnd.Format(time.RFC3339), query)
 	}
 	return datapoints
 }

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -227,7 +227,7 @@ func (p *Prometheus) runRangeQuery(query, metricName string, jobStart, jobEnd ti
 		log.Warnf("Error found parsing result from query %s: %s", query, err)
 	}
 	if len(datapoints) == 0 {
-		log.Warnf("No datapoints returned from metric %s", metricName)
+		log.Warnf("No datapoints returned from metric %s for job %s in range %s - %s with query %q", metricName, job.Name, jobStart.Format(time.RFC3339), jobEnd.Format(time.RFC3339), query)
 	}
 	return datapoints
 }


### PR DESCRIPTION
## Type of change

- Optimization

## Description

Prometheus metrics collection & indexing is too verbose, most of these messages are not very useful. Moving them to debug and adding some new warn messages, useful for debugging purposes (i.e: prometheus query not returning anything)

The biggest problem I see with this approach is that the Prometheus indexing progress is not shown to the user, which can be confused with another issue.

## Related Tickets & Documents

- Related Issue #
- Closes #
