### PR TITLE
Fix negative VMI measurement latencies

### DIFF
--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -58,40 +58,42 @@ type vmiMetric struct {
 	// Timestamp filed is very important the the elasticsearch indexing and represents the first creation time that we track (i.e., vm or vmi)
 	Timestamp time.Time `json:"timestamp"`
 
-	podCreated                time.Time
-	PodCreatedLatency         int64 `json:"podCreatedLatency"`
-	podScheduled              time.Time
-	PodScheduledLatency       int64 `json:"podScheduledLatency"`
-	podInitialized            time.Time
-	PodInitializedLatency     int64 `json:"podInitializedLatency"`
-	podContainersReady        time.Time
-	PodContainersReadyLatency int64 `json:"podContainersReadyLatency"`
-	podReady                  time.Time
-	PodReadyLatency           int64 `json:"podReadyLatency"`
-	vmiCreated                time.Time
-	VMICreatedLatency         int64 `json:"vmiCreatedLatency"`
-	vmiPending                time.Time
-	VMIPendingLatency         int64 `json:"vmiPendingLatency"`
-	vmiScheduling             time.Time
-	VMISchedulingLatency      int64 `json:"vmiSchedulingLatency"`
-	vmiScheduled              time.Time
-	VMIScheduledLatency       int64 `json:"vmiScheduledLatency"`
-	vmiRunning                time.Time
-	VMIRunningLatency         int64 `json:"vmiRunningLatency"`
-	vmReady                   time.Time
-	VMReadyLatency            int64  `json:"vmReadyLatency"`
-	MetricName                string `json:"metricName"`
-	UUID                      string `json:"uuid"`
-	Namespace                 string `json:"namespace"`
-	PodName                   string `json:"podName,omitempty"`
-	VMName                    string `json:"vmName,omitempty"`
-	VMIName                   string `json:"vmiName,omitempty"`
-	NodeName                  string `json:"nodeName"`
-	JobName                   string `json:"jobName,omitempty"`
-	Metadata                  any    `json:"metadata,omitempty"`
-	JobIteration              int    `json:"jobIteration"`
-	Replica                   int    `json:"replica"`
-	ChurnMetric               bool   `json:"churnMetric,omitempty"`
+	podCreated                       time.Time
+	PodCreatedLatency                int64 `json:"podCreatedLatency"`
+	podScheduled                     time.Time
+	PodScheduledLatency              int64 `json:"podScheduledLatency"`
+	podInitialized                   time.Time
+	PodInitializedLatency            int64 `json:"podInitializedLatency"`
+	podContainersReady               time.Time
+	PodContainersReadyLatency        int64 `json:"podContainersReadyLatency"`
+	podReady                         time.Time
+	PodReadyLatency                  int64 `json:"podReadyLatency"`
+	podReadyToStartContainers        time.Time
+	PodReadyToStartContainersLatency int64 `json:"podReadyToStartContainersLatency"`
+	vmiCreated                       time.Time
+	VMICreatedLatency                int64 `json:"vmiCreatedLatency"`
+	vmiPending                       time.Time
+	VMIPendingLatency                int64 `json:"vmiPendingLatency"`
+	vmiScheduling                    time.Time
+	VMISchedulingLatency             int64 `json:"vmiSchedulingLatency"`
+	vmiScheduled                     time.Time
+	VMIScheduledLatency              int64 `json:"vmiScheduledLatency"`
+	vmiRunning                       time.Time
+	VMIRunningLatency                int64 `json:"vmiRunningLatency"`
+	vmReady                          time.Time
+	VMReadyLatency                   int64  `json:"vmReadyLatency"`
+	MetricName                       string `json:"metricName"`
+	UUID                             string `json:"uuid"`
+	Namespace                        string `json:"namespace"`
+	PodName                          string `json:"podName,omitempty"`
+	VMName                           string `json:"vmName,omitempty"`
+	VMIName                          string `json:"vmiName,omitempty"`
+	NodeName                         string `json:"nodeName"`
+	JobName                          string `json:"jobName,omitempty"`
+	Metadata                         any    `json:"metadata,omitempty"`
+	JobIteration                     int    `json:"jobIteration"`
+	Replica                          int    `json:"replica"`
+	ChurnMetric                      bool   `json:"churnMetric,omitempty"`
 }
 
 type vmiLatency struct {
@@ -200,25 +202,27 @@ func (vmi *vmiLatency) handleUpdateVMI(obj any) {
 	if vmiM, ok := vmi.Metrics.Load(mapID); ok {
 		vmiMetric := vmiM.(vmiMetric)
 		if vmiMetric.vmiRunning.IsZero() {
-			switch vmiObj.Status.Phase {
-			case kvv1.Pending:
-				if vmiMetric.vmiPending.IsZero() {
-					vmiMetric.vmiPending = time.Now().UTC()
+			for _, phase := range vmiObj.Status.PhaseTransitionTimestamps {
+				switch phase.Phase {
+				case kvv1.Pending:
+					if vmiMetric.vmiPending.IsZero() {
+						vmiMetric.vmiPending = phase.PhaseTransitionTimestamp.UTC()
+					}
+				case kvv1.Scheduling:
+					if vmiMetric.vmiScheduling.IsZero() {
+						vmiMetric.vmiScheduling = phase.PhaseTransitionTimestamp.UTC()
+					}
+				case kvv1.Scheduled:
+					if vmiMetric.vmiScheduled.IsZero() {
+						vmiMetric.vmiScheduled = phase.PhaseTransitionTimestamp.UTC()
+					}
+				case kvv1.Running:
+					log.Debugf("VMI %s is running", vmiObj.Name)
+					vmiMetric.vmiRunning = phase.PhaseTransitionTimestamp.UTC()
 				}
-			case kvv1.Scheduling:
-				if vmiMetric.vmiScheduling.IsZero() {
-					vmiMetric.vmiScheduling = time.Now().UTC()
-				}
-			case kvv1.Scheduled:
-				if vmiMetric.vmiScheduled.IsZero() {
-					vmiMetric.vmiScheduled = time.Now().UTC()
-				}
-			case kvv1.Running:
-				log.Debugf("VMI %s is running", vmiObj.Name)
-				vmiMetric.vmiRunning = time.Now().UTC()
 			}
-			vmi.Metrics.Store(mapID, vmiMetric)
 		}
+		vmi.Metrics.Store(mapID, vmiMetric)
 	}
 }
 
@@ -238,7 +242,7 @@ func (vmi *vmiLatency) handleCreateVMIPod(obj any) {
 		vmiMetric := v.(vmiMetric)
 		if vmiMetric.VMIName == vmiName {
 			vmiMetric.PodName = pod.Name
-			vmiMetric.podCreated = time.Now().UTC()
+			vmiMetric.podCreated = pod.CreationTimestamp.UTC()
 			vmi.Metrics.Store(k, vmiMetric)
 		}
 		return true
@@ -262,6 +266,32 @@ func (vmi *vmiLatency) handleUpdateVMIPod(obj any) {
 		if vmiMetric.VMIName == vmiName {
 			if vmiMetric.podReady.IsZero() {
 				for _, c := range pod.Status.Conditions {
+					if c.Status == corev1.ConditionTrue {
+						// https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
+						switch c.Type {
+						case corev1.PodScheduled:
+							if vmiMetric.podScheduled.IsZero() {
+								vmiMetric.podScheduled = c.LastTransitionTime.UTC()
+								vmiMetric.NodeName = pod.Spec.NodeName
+							}
+						case corev1.PodReadyToStartContainers:
+							if vmiMetric.podReadyToStartContainers.IsZero() {
+								vmiMetric.podReadyToStartContainers = c.LastTransitionTime.UTC()
+							}
+						case corev1.PodInitialized:
+							if vmiMetric.podInitialized.IsZero() {
+								vmiMetric.podInitialized = c.LastTransitionTime.UTC()
+							}
+						case corev1.ContainersReady:
+							if vmiMetric.podContainersReady.IsZero() {
+								vmiMetric.podContainersReady = c.LastTransitionTime.UTC()
+							}
+						case corev1.PodReady:
+							log.Debugf("VMI pod %s is running", pod.Name)
+							vmiMetric.podReady = c.LastTransitionTime.UTC()
+						}
+					}
+
 					if c.Status == corev1.ConditionTrue {
 						switch c.Type {
 						case corev1.PodScheduled:
@@ -378,6 +408,7 @@ func (vmi *vmiLatency) normalizeMetrics() float64 {
 		m.PodInitializedLatency = m.podInitialized.Sub(m.Timestamp).Milliseconds()
 		m.PodContainersReadyLatency = m.podContainersReady.Sub(m.Timestamp).Milliseconds()
 		m.PodReadyLatency = m.podReady.Sub(m.Timestamp).Milliseconds()
+		m.PodReadyToStartContainersLatency = m.podReadyToStartContainers.Sub(m.Timestamp).Milliseconds()
 		m.UUID = vmi.Uuid
 		m.JobName = vmi.JobConfig.Name
 		m.Metadata = vmi.Metadata
@@ -391,16 +422,17 @@ func (vmi *vmiLatency) normalizeMetrics() float64 {
 func (vmi *vmiLatency) getLatency(normLatency any) map[string]float64 {
 	vmiMetric := normLatency.(vmiMetric)
 	return map[string]float64{
-		"VM" + string(kvv1.VirtualMachineReady): float64(vmiMetric.VMReadyLatency),
-		"VMICreated":                            float64(vmiMetric.VMICreatedLatency),
-		"VMI" + string(kvv1.Pending):            float64(vmiMetric.VMIPendingLatency),
-		"VMI" + string(kvv1.Scheduling):         float64(vmiMetric.VMISchedulingLatency),
-		"VMI" + string(kvv1.Scheduled):          float64(vmiMetric.VMIScheduledLatency),
-		"VMI" + string(kvv1.Running):            float64(vmiMetric.VMIRunningLatency),
-		"PodCreated":                            float64(vmiMetric.PodCreatedLatency),
-		"Pod" + string(corev1.PodScheduled):     float64(vmiMetric.PodScheduledLatency),
-		"Pod" + string(corev1.PodInitialized):   float64(vmiMetric.PodInitializedLatency),
-		"Pod" + string(corev1.ContainersReady):  float64(vmiMetric.PodContainersReadyLatency),
+		"VM" + string(kvv1.VirtualMachineReady):          float64(vmiMetric.VMReadyLatency),
+		"VMICreated":                                     float64(vmiMetric.VMICreatedLatency),
+		"VMI" + string(kvv1.Pending):                     float64(vmiMetric.VMIPendingLatency),
+		"VMI" + string(kvv1.Scheduling):                  float64(vmiMetric.VMISchedulingLatency),
+		"VMI" + string(kvv1.Scheduled):                   float64(vmiMetric.VMIScheduledLatency),
+		"VMI" + string(kvv1.Running):                     float64(vmiMetric.VMIRunningLatency),
+		"PodCreated":                                     float64(vmiMetric.PodCreatedLatency),
+		"Pod" + string(corev1.PodScheduled):              float64(vmiMetric.PodScheduledLatency),
+		"Pod" + string(corev1.PodInitialized):            float64(vmiMetric.PodInitializedLatency),
+		"Pod" + string(corev1.ContainersReady):           float64(vmiMetric.PodContainersReadyLatency),
+		"Pod" + string(corev1.PodReadyToStartContainers): float64(vmiMetric.PodReadyToStartContainersLatency),
 	}
 }
 

--- a/pkg/measurements/vmi_latency.go
+++ b/pkg/measurements/vmi_latency.go
@@ -291,27 +291,6 @@ func (vmi *vmiLatency) handleUpdateVMIPod(obj any) {
 							vmiMetric.podReady = c.LastTransitionTime.UTC()
 						}
 					}
-
-					if c.Status == corev1.ConditionTrue {
-						switch c.Type {
-						case corev1.PodScheduled:
-							if vmiMetric.podScheduled.IsZero() {
-								vmiMetric.podScheduled = time.Now().UTC()
-								vmiMetric.NodeName = pod.Spec.NodeName
-							}
-						case corev1.PodInitialized:
-							if vmiMetric.podInitialized.IsZero() {
-								vmiMetric.podInitialized = time.Now().UTC()
-							}
-						case corev1.ContainersReady:
-							if vmiMetric.podContainersReady.IsZero() {
-								vmiMetric.podContainersReady = time.Now().UTC()
-							}
-						case corev1.PodReady:
-							log.Debugf("VMI pod %s is running", pod.Name)
-							vmiMetric.podReady = time.Now().UTC()
-						}
-					}
 				}
 			}
 			vmi.Metrics.Store(k, vmiMetric)
@@ -469,7 +448,7 @@ func (vmi *vmiLatency) IsCompatible() bool {
 // - metadata: name, namespace, uid, creationTimestamp, labels
 // - status: conditions
 func virtualMachineTransformFunc() cache.TransformFunc {
-	return func(obj interface{}) (interface{}, error) {
+	return func(obj any) (any, error) {
 		u, ok := obj.(*unstructured.Unstructured)
 		if !ok {
 			return obj, nil
@@ -489,7 +468,7 @@ func virtualMachineTransformFunc() cache.TransformFunc {
 // - metadata: name, namespace, uid, creationTimestamp, labels, ownerReferences
 // - status: phase
 func virtualMachineInstanceTransformFunc() cache.TransformFunc {
-	return func(obj interface{}) (interface{}, error) {
+	return func(obj any) (any, error) {
 		u, ok := obj.(*unstructured.Unstructured)
 		if !ok {
 			return obj, nil
@@ -503,6 +482,9 @@ func virtualMachineInstanceTransformFunc() cache.TransformFunc {
 
 		if phase, found, _ := unstructured.NestedString(u.Object, "status", "phase"); found {
 			_ = unstructured.SetNestedField(minimal.Object, phase, "status", "phase")
+		}
+		if phaseTransitionTimestamps, found, _ := unstructured.NestedSlice(u.Object, "status", "phaseTransitionTimestamps"); found {
+			_ = unstructured.SetNestedSlice(minimal.Object, phaseTransitionTimestamps, "status", "phaseTransitionTimestamps")
 		}
 
 		return minimal, nil


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

This measurement used an outdated approach to calculate latencies, relying on local timestamps rather than pod/VMI condition timestamps. This proved to be error-prone for small latencies, as the Kubernetes API rounds timestamps to second-level precision.

```shell
time="2026-04-01 14:29:17" level=info msg="virt-density: PodCreated 99th: 1017 ms max: 1059 ms avg: -46116859600 ms" file="base_measurement.go:128"
time="2026-04-01 14:29:17" level=info msg="virt-density: VMICreated 99th: 0 ms max: 1000 ms avg: -46116860183 ms" file="base_measurement.go:128"
time="2026-04-01 14:29:17" level=info msg="virt-density: VMIPending 99th: 1002 ms max: 1042 ms avg: -34587644564 ms" file="base_measurement.go:128"
time="2026-04-01 14:29:17" level=info msg="virt-density: VMIScheduling 99th: 1063 ms max: 1546 ms avg: 623 ms" file="base_measurement.go:128"
time="2026-04-01 14:29:17" level=info msg="virt-density: VMIRunning 99th: 153768 ms max: 161572 ms avg: 73988 ms" file="base_measurement.go:128"
time="2026-04-01 14:29:17" level=info msg="virt-density: VMReady 99th: 153789 ms max: 161607 ms avg: 74009 ms" file="base_measurement.go:128"
time="2026-04-01 14:29:17" level=info msg="virt-density: PodPodScheduled 99th: 1019 ms max: 1060 ms avg: -46116859594 ms" file="base_measurement.go:128"
time="2026-04-01 14:29:17" level=info msg="virt-density: PodInitialized 99th: 97085 ms max: 106805 ms avg: -46116820850 ms" file="base_measurement.go:128"
time="2026-04-01 14:29:17" level=info msg="virt-density: PodContainersReady 99th: 134447 ms max: 141216 ms avg: -46116797416 ms" file="base_measurement.go:128"
```

For example, in the snippet above, avg PodCreated lower than 0 b/c the the vmi creation timestamp was taken from the object's _creationTimestamp_ value, which normally is rounded down to the lowest second, the pod creation latency calculation is calculated from timestamp when the pod was observed by kube-burner (this timestamp is not rounded up) kube-burner timestamp - creationTimestamp 

This PR fixes this behavior by using the same logic available in pod latency measurements.

cc @josecastillolema @jeniferh

Also adding the missing/new PodReadyToStartContainers condition to the metric.

## Related Tickets & Documents

- Related Issue #
- Closes #


## Tests

Works fine

```shell
time="2026-04-08 22:09:53" level=info msg="Evaluating latency thresholds" file="metrics.go:48"
time="2026-04-08 22:09:53" level=info msg="virt-density: VMIPending 99th: 1000 ms max: 1000 ms avg: 415 ms" file="base_measurement.go:129"
time="2026-04-08 22:09:53" level=info msg="virt-density: VMIRunning 99th: 60500 ms max: 62000 ms avg: 40123 ms" file="base_measurement.go:129"
time="2026-04-08 22:09:53" level=info msg="virt-density: PodCreated 99th: 1000 ms max: 1000 ms avg: 483 ms" file="base_measurement.go:129"
time="2026-04-08 22:09:53" level=info msg="virt-density: VMICreated 99th: 1000 ms max: 1000 ms avg: 415 ms" file="base_measurement.go:129"
time="2026-04-08 22:09:53" level=info msg="virt-density: PodInitialized 99th: 33000 ms max: 33000 ms avg: 19876 ms" file="base_measurement.go:129"
time="2026-04-08 22:09:53" level=info msg="virt-density: PodPodReadyToStartContainers 99th: 16500 ms max: 17000 ms avg: 7449 ms" file="base_measurement.go:129"
time="2026-04-08 22:09:53" level=info msg="virt-density: VMIScheduled 99th: 53000 ms max: 54000 ms avg: 33067 ms" file="base_measurement.go:129"
time="2026-04-08 22:09:53" level=info msg="virt-density: PodPodScheduled 99th: 1000 ms max: 1000 ms avg: 483 ms" file="base_measurement.go:129"
time="2026-04-08 22:09:53" level=info msg="virt-density: VMIScheduling 99th: 1500 ms max: 2000 ms avg: 494 ms" file="base_measurement.go:129"
time="2026-04-08 22:09:53" level=info msg="virt-density: PodContainersReady 99th: 53000 ms max: 54000 ms avg: 33067 ms" file="base_measurement.go:129"

```
