### PR TITLE
Fix image preload for VMIs

### DIFF
--- a/pkg/burner/pre_load.go
+++ b/pkg/burner/pre_load.go
@@ -153,7 +153,7 @@ func countPulledImages(ctx context.Context, clientSet kubernetes.Interface, seen
 				continue
 			}
 			pullCount++
-			if status.ImageID != "" {
+			if status.Image != "" {
 				seen[podName+"/"+status.Name] = struct{}{}
 				pulledCount++
 			}
@@ -270,6 +270,7 @@ func createDSs(ctx context.Context, clientSet kubernetes.Interface, imageList []
 		ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, corev1.Container{
 			Name:            fmt.Sprintf("pull-%d", i),
 			Image:           image,
+			Command:         []string{"override", "command"},
 			ImagePullPolicy: corev1.PullAlways,
 		})
 	}


### PR DESCRIPTION
## Type of change

- Bug fix

## Description

Image preload wasn't working correctly for VMIs, it was timing out as demonstrated at https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-metal-4.22-nightly-x86-daily-virt-6nodes/2041788597949960192/artifacts/daily-virt-6nodes/openshift-qe-virt-density-nomount/build-log.txt

This is because the ImageID is not being set (the _image_ field does not show these issues), I'm not sure why at the moment, it's possible that the cause is the image format used by kubevirt doesn't allow that.

Also adding an override command to the preloaded images in the DS to prevent running the default container entrypoint.

## Related Tickets & Documents

- Related Issue #
- Closes #
