### PR TITLE
fix(errors): update EnhanceYAMLParseError test assertions to match format

### DIFF
--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -45,8 +45,9 @@ var _ = Describe("Error Enhancement", func() {
 				result := errors.EnhanceYAMLParseError("config.yml", yamlErr)
 
 				Expect(result).To(HaveOccurred())
-				Expect(result.Error()).Should(ContainSubstring("failed to parse config file config.yml"))
-				Expect(result.Error()).Should(ContainSubstring("line 5: invalid syntax; line 10: unknown field"))
+				Expect(result.Error()).Should(ContainSubstring("failed to parse config file: config.yml:"))
+				Expect(result.Error()).Should(ContainSubstring("line 5: invalid syntax"))
+				Expect(result.Error()).Should(ContainSubstring("line 10: unknown field"))
 			})
 		})
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Fixes the `EnhanceYAMLParseError` test case that was failing on `main`. 

The format string in `errors.go` (line 33) was updated previously to include colons and join errors with newlines, but the test assertions were never updated to reflect this change. The test was still looking for the old format (no colons) and expected the errors to be joined with semicolons.

This PR updates the test assertions to match the actual function output, adding the missing colons and splitting the error checks so they work correctly with the new newline separator.

## Related Tickets & Documents

- Closes #1212
